### PR TITLE
use explicit target dependencies for DOTS models

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 add_library(${EXPORT_NAME}::${EXPORT_NAME} ALIAS ${TARGET_NAME})
 
 # properties
-GENERATE_DOTS_TYPES(MODEL_SOURCES MODEL_HEADERS
+target_dots_model(${TARGET_NAME}
     ${CMAKE_CURRENT_LIST_DIR}/../external/dots/model/descriptors.dots
     ${CMAKE_CURRENT_LIST_DIR}/../external/dots/model/dotsmessages.dots
     ${CMAKE_CURRENT_LIST_DIR}/../external/dots/model/dotstypes.dots
@@ -97,8 +97,6 @@ target_sources(${TARGET_NAME}
         src/type/StructDescriptor.cpp
         src/type/Uuid.cpp
         src/type/VectorDescriptor.cpp
-
-        ${MODEL_SOURCES}
 )
 target_include_directories(${TARGET_NAME}
     PUBLIC
@@ -191,7 +189,7 @@ install(DIRECTORY
     COMPONENT dev
 )
 install(FILES
-    ${MODEL_HEADERS}
+    ${${TARGET_NAME}-MODEL_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT dev
 )


### PR DESCRIPTION
The C++ CMake layer for the DOTS code generator currently uses
add_custom_command to create generation targets for every passed DOTS
model file. These targets are then implicitly added as dependencies to
all targets created in the same directory (see [1]).

However, this only applies to targets that are actually being built.
Some CMake targets, particularly interface libraries (i.e. header-only
libraries), are not being built and are therefore not generating any
header files. This makes it impossible to create header-only model
libraries without using workarounds.

Instead of using an implicit mechanism to create the target dependency,
a custom target can be created and added as an explicit dependency to a
target that is passed via a parameter. Because custom targets are
always being built (even though the have no output), the headers are
also generated for targets that are not built themselves.

Additionally, the function can be used in a way that is closer to the
"modern" CMake approach of adding properties to targets, which might
make it more intuitive to use.

References:

 - [1] https://cmake.org/cmake/help/v3.12/command/add_custom_command.html