### PR TITLE
Implement dots echo

### DIFF
--- a/external/dots/model/dotsmessages.dots
+++ b/external/dots/model/dotsmessages.dots
@@ -59,7 +59,7 @@ struct DotsMsgHello [internal,cached=false] {
 struct DotsEcho [internal,cached=false] {
     1: bool request;
     2: uint32 identifier;
-    3: uint32 sequenceNr;
+    3: uint32 sequenceNumber;
     4: string data;
 }
 

--- a/external/dots/model/dotsmessages.dots
+++ b/external/dots/model/dotsmessages.dots
@@ -56,6 +56,13 @@ struct DotsMsgHello [internal,cached=false] {
     3: bool authenticationRequired;
 }
 
+struct DotsEcho [internal,cached=false] {
+    1: bool request;
+    2: uint32 identifier;
+    3: uint32 sequenceNr;
+    4: string data;
+}
+
 struct DotsTransportHeader [internal,cached=false] {
     1: [deprecated] string nameSpace;
     2: [deprecated] string destinationGroup;

--- a/external/dots/model/dotsmessages.dots
+++ b/external/dots/model/dotsmessages.dots
@@ -56,8 +56,14 @@ struct DotsMsgHello [internal,cached=false] {
     3: bool authenticationRequired;
 }
 
+// Used for echo/ping function of host-transceiver:
+// The DOTS guest may send a DotsEcho to the host, the host just returns the sent
+// data back to the client.
+// A guest can use this to implement a keep-alive, a connection-check or to measure
+// the latency between the guest and the host.
+// The usage of 'identifier', 'sequenceNumber' is defined by the guest.
 struct DotsEcho [internal,cached=false] {
-    1: bool request;
+    1: bool request; //< Need to be set to 'true' when requesting, 'false' when host replies.
     2: uint32 identifier;
     3: uint32 sequenceNumber;
     4: string data;

--- a/lib/include/dots/io/Connection.h
+++ b/lib/include/dots/io/Connection.h
@@ -26,7 +26,7 @@ namespace dots::io
         static constexpr id_t HostId = 1;
         static constexpr id_t FirstGuestId = 2;
 
-        using receive_handler_t = std::function<bool(Connection&, Transmission)>;
+        using receive_handler_t = std::function<void(Connection&, Transmission)>;
         using transition_handler_t = std::function<void(Connection&, const std::exception_ptr&)>;
 
         Connection(channel_ptr_t channel, bool host, std::optional<std::string> authSecret = std::nullopt);

--- a/lib/include/dots/io/HostTransceiver.h
+++ b/lib/include/dots/io/HostTransceiver.h
@@ -56,7 +56,7 @@ namespace dots::io
         bool handleListenAccept(Listener& listener, channel_ptr_t channel);
         void handleListenError(Listener& listener, const std::exception_ptr& e);
 
-        bool handleTransmission(io::Connection& connection, Transmission transmission);
+        void handleTransmission(io::Connection& connection, Transmission transmission);
         void handleTransition(io::Connection& connection, const std::exception_ptr& e) noexcept;
 
         void handleMemberMessage(io::Connection& connection, const DotsMember& member);

--- a/lib/include/dots/io/HostTransceiver.h
+++ b/lib/include/dots/io/HostTransceiver.h
@@ -9,6 +9,7 @@
 #include <DotsClearCache.dots.h>
 #include <DotsDescriptorRequest.dots.h>
 #include <DotsMember.dots.h>
+#include <DotsEcho.dots.h>
 
 namespace dots::io
 {
@@ -62,6 +63,7 @@ namespace dots::io
         void handleMemberMessage(io::Connection& connection, const DotsMember& member);
         void handleDescriptorRequest(io::Connection& connection, const DotsDescriptorRequest& descriptorRequest);
         void handleClearCache(io::Connection& connection, const DotsClearCache& clearCache);
+        void handleEchoRequest(io::Connection& connection, const DotsEcho& clearCache);
 
         void transmitContainer(io::Connection& connection, const Container<>& container);
 

--- a/lib/include/dots/io/HostTransceiver.h
+++ b/lib/include/dots/io/HostTransceiver.h
@@ -63,7 +63,7 @@ namespace dots::io
         void handleMemberMessage(io::Connection& connection, const DotsMember& member);
         void handleDescriptorRequest(io::Connection& connection, const DotsDescriptorRequest& descriptorRequest);
         void handleClearCache(io::Connection& connection, const DotsClearCache& clearCache);
-        void handleEchoRequest(io::Connection& connection, const DotsEcho& clearCache);
+        void handleEchoRequest(io::Connection& connection, const DotsEcho& echoRequest);
 
         void transmitContainer(io::Connection& connection, const Container<>& container);
 

--- a/lib/src/io/HostTransceiver.cpp
+++ b/lib/src/io/HostTransceiver.cpp
@@ -111,7 +111,7 @@ namespace dots::io
     {
         auto connection = std::make_shared<io::Connection>(std::move(channel), true);
         connection->asyncReceive(registry(), m_authManager.get(), selfName(),
-            [this](io::Connection& connection, Transmission transmission) { return handleTransmission(connection, std::move(transmission)); },
+            [this](io::Connection& connection, Transmission transmission) { handleTransmission(connection, std::move(transmission)); },
             [this](io::Connection& connection, const std::exception_ptr& e) { handleTransition(connection, e); }
         );
         m_guestConnections.emplace(connection.get(), connection);
@@ -134,7 +134,7 @@ namespace dots::io
         m_listeners.erase(&listener);
     }
 
-    bool HostTransceiver::handleTransmission(io::Connection& connection, Transmission transmission)
+    void HostTransceiver::handleTransmission(io::Connection& connection, Transmission transmission)
     {
         const auto& [header, instance] = transmission;
 
@@ -156,8 +156,6 @@ namespace dots::io
 
         dispatcher().dispatch(transmission);
         transmit(&connection, std::move(transmission));
-
-        return true;
     }
 
     void HostTransceiver::handleTransition(io::Connection& connection, const std::exception_ptr& e) noexcept

--- a/lib/src/io/HostTransceiver.cpp
+++ b/lib/src/io/HostTransceiver.cpp
@@ -143,10 +143,12 @@ namespace dots::io
             if (auto* member = instance.as<DotsMember>())
             {
                 handleMemberMessage(connection, *member);
+                return;
             }
             else if (auto* descriptorRequest = instance.as<DotsDescriptorRequest>())
             {
                 handleDescriptorRequest(connection, *descriptorRequest);
+                return;
             }
             else if (auto* clearCache = instance.as<DotsClearCache>())
             {

--- a/lib/src/io/HostTransceiver.cpp
+++ b/lib/src/io/HostTransceiver.cpp
@@ -154,6 +154,11 @@ namespace dots::io
             {
                 handleClearCache(connection, *clearCache);
             }
+            else if (auto* echoRequest = instance.as<DotsEcho>())
+            {
+                handleEchoRequest(connection, *echoRequest);
+                return;
+            }
         }
 
         dispatcher().dispatch(transmission);
@@ -335,6 +340,17 @@ namespace dots::io
                 }
             }
         }
+    }
+
+    void HostTransceiver::handleEchoRequest(io::Connection& connection, const DotsEcho& echoRequest)
+    {
+        if  (echoRequest.request == true)
+        {
+            DotsEcho echoReply(echoRequest);
+            echoReply.request = false;
+            connection.transmit(echoReply);
+        }
+
     }
 
     void HostTransceiver::transmitContainer(io::Connection& connection, const Container<>& container)

--- a/lib/src/io/HostTransceiver.cpp
+++ b/lib/src/io/HostTransceiver.cpp
@@ -350,7 +350,6 @@ namespace dots::io
             echoReply.request = false;
             connection.transmit(echoReply);
         }
-
     }
 
     void HostTransceiver::transmitContainer(io::Connection& connection, const Container<>& container)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(${TARGET_NAME}
         src/TestProxyProperty.cpp
         src/TestIpNetwork.cpp
         src/TestLegacyAuthManager.cpp
+        src/TestHostTransceiver.cpp
 )
 target_include_directories(${TARGET_NAME}
     PRIVATE
@@ -49,7 +50,7 @@ target_include_directories(${TARGET_NAME}
 )
 target_compile_options(${TARGET_NAME}
     PRIVATE
-        $<$<CXX_COMPILER_ID:GNU>:$<$<NOT:$<BOOL:${CMAKE_CXX_FLAGS}>>:-O2 -Wall -Wextra -Wpedantic -Werror>>
+        $<$<CXX_COMPILER_ID:GNU>:$<$<NOT:$<BOOL:${CMAKE_CXX_FLAGS}>>:-O2 -Wall -Wextra -Wpedantic -Werror -Wno-missing-field-initializers>>
         $<$<CXX_COMPILER_ID:MSVC>:/W4>
 )
 target_compile_definitions(${TARGET_NAME}

--- a/tests/src/TestHostTransceiver.cpp
+++ b/tests/src/TestHostTransceiver.cpp
@@ -1,0 +1,39 @@
+#include <optional>
+#include <dots/testing/gtest/gtest.h>
+#include <dots/testing/gtest/PublishTestBase.h>
+#include <dots/io/HostTransceiver.h>
+#include <dots/tools/fun.h>
+
+struct TestHostTransceiver : dots::testing::PublishTestBase
+{
+protected:
+
+    TestHostTransceiver()
+    {
+        /* do nothing */
+    }
+
+};
+
+TEST_F(TestHostTransceiver, testDotsEcho)
+{
+    std::optional<DotsEcho> reply;
+
+    dots::io::Subscription subscription = dots::subscribe<DotsEcho>([&](const DotsEcho::Cbd& event) {
+        reply = event();
+    });
+
+    dots::publish(DotsEcho{
+        DotsEcho::request_i(true),
+        DotsEcho::identifier_i(0),
+        DotsEcho::sequenceNr_i(1)
+    });
+
+    processEvents();
+
+    ASSERT_TRUE(reply.has_value());
+    EXPECT_EQ(false, reply->request);
+    EXPECT_EQ(0, reply->identifier);
+    EXPECT_EQ(1, reply->sequenceNr);
+
+}

--- a/tests/src/TestHostTransceiver.cpp
+++ b/tests/src/TestHostTransceiver.cpp
@@ -26,14 +26,14 @@ TEST_F(TestHostTransceiver, testDotsEcho)
     dots::publish(DotsEcho{
         DotsEcho::request_i(true),
         DotsEcho::identifier_i(0),
-        DotsEcho::sequenceNr_i(1)
+        DotsEcho::sequenceNumber_i(1)
     });
 
     processEvents();
 
     ASSERT_TRUE(reply.has_value());
     EXPECT_EQ(false, reply->request);
-    EXPECT_EQ(0, reply->identifier);
-    EXPECT_EQ(1, reply->sequenceNr);
+    EXPECT_EQ(0u, reply->identifier);
+    EXPECT_EQ(1u, reply->sequenceNumber);
 
 }


### PR DESCRIPTION
DotsEcho is created with RFC792 "Echo Message" in mind. Instead of using
two separete types for request and reply, a boolean is used instead.
The HostTransceiver is expected to react to an DotsEcho{request=true}
with the return of the same object, but with request=false.