### PR TITLE
fix compile-problem with gcc11:

### DIFF
--- a/lib/include/dots/type/VectorDescriptor.h
+++ b/lib/include/dots/type/VectorDescriptor.h
@@ -68,7 +68,7 @@ namespace dots::type
 
             if (valueDescriptor().usesDynamicMemory())
             {
-                for (const T& value : lhs)
+                for (const auto& value : lhs)
                 {
                     dynMemUsage += valueDescriptor().dynamicMemoryUsage(value);
                 }


### PR DESCRIPTION
error: loop variable ‘value’ of type ‘const bool&’ binds to a temporary constructed from type ‘const unsigned char’