### PR TITLE
remove python dependency for dots-code-generator

### DIFF
--- a/dots-cg-cpp/src/DOTS-CG-CPP.cmake
+++ b/dots-cg-cpp/src/DOTS-CG-CPP.cmake
@@ -1,14 +1,5 @@
 # helper variables
-find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter)
-execute_process(COMMAND ${Python3_EXECUTABLE} -m site --user-site
-    OUTPUT_VARIABLE Python3_SITEUSER
-    RESULT_VARIABLE rv
-)
-if (${rv} GREATER 2)
-    message(FATAL_ERROR "Could not determine Python3 user site-package location: ${rv}")
-endif()
-string(REPLACE "\n" "" Python3_SITEUSER ${Python3_SITEUSER})
-find_program(DOTS-CG NAMES dcg.py PATHS ${Python3_SITEARCH} ${Python3_SITEUSER} PATH_SUFFIXES bin)
+find_program(DOTS-CG NAMES dcg.py PATHS PATH_SUFFIXES bin)
 if(${DOTS-CG} STREQUAL DOTS-CG-NOTFOUND)
     message(FATAL_ERROR "Could not find DOTS code generator")
 endif()
@@ -24,7 +15,7 @@ set(DOTS-CG_TEMPLATE_LIST
     CACHE INTERNAL "Internal helper variable containing the C++ code generation templates"
 )
 set(DOTS-CG-CPP-GENERATE_CMD 
-    ${Python3_EXECUTABLE} ${DOTS-CG} --config=${DOTS-CG-CPP_DIR}/${DOTS-CG_CONFIG}.py --templatePath=${DOTS-CG_TEMPLATE_DIR}
+    ${DOTS-CG} --config=${DOTS-CG-CPP_DIR}/${DOTS-CG_CONFIG}.py --templatePath=${DOTS-CG_TEMPLATE_DIR}
     CACHE INTERNAL "Internal helper variable containing the DOTS-CG generate command"
 )
 


### PR DESCRIPTION
DCG should be treated as a normal program, not assuming it's implemented
in a specific language.