### PR TITLE
Fix usage of preceding header data in legacy reads

### DIFF
--- a/lib/include/dots/io/channels/AsyncStreamChannel.h
+++ b/lib/include/dots/io/channels/AsyncStreamChannel.h
@@ -481,6 +481,7 @@ namespace dots::io
         {
             if constexpr (TransmissionFormat == TransmissionFormat::Legacy)
             {
+                m_transportHeader = {};
                 m_serializer.deserialize(m_transportHeader);
 
                 if (!m_transportHeader.payloadSize.isValid())


### PR DESCRIPTION
When using the legacy transmission format, the transport header
instance is currently not reset.

Because of this, property values of previous reads can be present in a
subsequent read when they are not overwritten by the new transmission.

This can cause incorrect behavior; e.g when a transmission is falsely
using the remove flag of a preceding one.