### PR TITLE
Change license of dots-cpp to LGPLv3

### DIFF
--- a/LICENSE.LESSER
+++ b/LICENSE.LESSER
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/bin/dotsd/src/DotsDaemon.cpp
+++ b/bin/dotsd/src/DotsDaemon.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <DotsDaemon.h>
 #ifdef __unix__
 #include <sys/resource.h>

--- a/bin/dotsd/src/DotsDaemon.h
+++ b/bin/dotsd/src/DotsDaemon.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <optional>

--- a/bin/dotsd/src/main.cpp
+++ b/bin/dotsd/src/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 
 #include <boost/program_options.hpp>
 #include <iostream>

--- a/bin/examples/object-reader/src/main.cpp
+++ b/bin/examples/object-reader/src/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <iostream>
 #include <dots/Application.h>
 #include <dots/type/AnyStruct.h>

--- a/bin/examples/object-trace/src/main.cpp
+++ b/bin/examples/object-trace/src/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <iostream>
 #include <dots/Application.h>
 #include <dots/tools/logging.h>

--- a/bin/examples/roundtrip/src/main.cpp
+++ b/bin/examples/roundtrip/src/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <iostream>
 #include <dots/Application.h>
 #include <RoundtripData.dots.h>

--- a/bin/examples/smart-home/src/Basement.cpp
+++ b/bin/examples/smart-home/src/Basement.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <Basement.h>
 #include <LightControl.dots.h>
 

--- a/bin/examples/smart-home/src/Basement.h
+++ b/bin/examples/smart-home/src/Basement.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/dots.h>

--- a/bin/examples/smart-home/src/LivingRoom.cpp
+++ b/bin/examples/smart-home/src/LivingRoom.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <LivingRoom.h>
 #include <LightControl.dots.h>
 

--- a/bin/examples/smart-home/src/LivingRoom.h
+++ b/bin/examples/smart-home/src/LivingRoom.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <dots/dots.h>

--- a/bin/examples/smart-home/src/Stairwell.cpp
+++ b/bin/examples/smart-home/src/Stairwell.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <Stairwell.h>
 #include <LightControl.dots.h>
 

--- a/bin/examples/smart-home/src/Stairwell.h
+++ b/bin/examples/smart-home/src/Stairwell.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/dots.h>
 #include <StatelessSwitch.dots.h>

--- a/bin/examples/smart-home/src/main.cpp
+++ b/bin/examples/smart-home/src/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <csignal>
 #include <dots/Application.h>
 #include <dots/tools/logging.h>

--- a/bin/examples/smart-home/tests/BasementTest.cpp
+++ b/bin/examples/smart-home/tests/BasementTest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/EventTestBase.h>
 #include <Basement.h>
 #include <LightControl.dots.h>

--- a/bin/examples/smart-home/tests/LivingRoomTest.cpp
+++ b/bin/examples/smart-home/tests/LivingRoomTest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/EventTestBase.h>
 #include <LivingRoom.h>
 #include <LightControl.dots.h>

--- a/bin/examples/smart-home/tests/StairwellTest.cpp
+++ b/bin/examples/smart-home/tests/StairwellTest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/EventTestBase.h>
 #include <Stairwell.h>
 #include <LightControl.dots.h>

--- a/lib/include/dots/Application.h
+++ b/lib/include/dots/Application.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/dots.h>

--- a/lib/include/dots/Connection.h
+++ b/lib/include/dots/Connection.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <tuple>

--- a/lib/include/dots/Container.h
+++ b/lib/include/dots/Container.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <functional>

--- a/lib/include/dots/ContainerPool.h
+++ b/lib/include/dots/ContainerPool.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <unordered_map>

--- a/lib/include/dots/Dispatcher.h
+++ b/lib/include/dots/Dispatcher.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <unordered_map>

--- a/lib/include/dots/Event.h
+++ b/lib/include/dots/Event.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/type/Struct.h>

--- a/lib/include/dots/GuestTransceiver.h
+++ b/lib/include/dots/GuestTransceiver.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <optional>

--- a/lib/include/dots/HostTransceiver.h
+++ b/lib/include/dots/HostTransceiver.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <unordered_map>
 #include <unordered_set>

--- a/lib/include/dots/Subscription.h
+++ b/lib/include/dots/Subscription.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/tools/Handler.h>

--- a/lib/include/dots/Timer.h
+++ b/lib/include/dots/Timer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 #include <dots/tools/Handler.h>

--- a/lib/include/dots/Transceiver.h
+++ b/lib/include/dots/Transceiver.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <optional>

--- a/lib/include/dots/asio.h
+++ b/lib/include/dots/asio.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <boost/asio.hpp>
 

--- a/lib/include/dots/asio_forward.h
+++ b/lib/include/dots/asio_forward.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 namespace boost::asio

--- a/lib/include/dots/dots.h
+++ b/lib/include/dots/dots.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 /*!

--- a/lib/include/dots/io/Channel.h
+++ b/lib/include/dots/io/Channel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <system_error>

--- a/lib/include/dots/io/DescriptorConverter.h
+++ b/lib/include/dots/io/DescriptorConverter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/Registry.h>
 #include <EnumDescriptorData.dots.h>

--- a/lib/include/dots/io/Endpoint.h
+++ b/lib/include/dots/io/Endpoint.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <dots/asio_forward.h>

--- a/lib/include/dots/io/FdObserver.h
+++ b/lib/include/dots/io/FdObserver.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <exception>
 #include <dots/asio.h>

--- a/lib/include/dots/io/GlobalType.h
+++ b/lib/include/dots/io/GlobalType.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/StructDescriptor.h>
 #include <dots/type/DescriptorMap.h>

--- a/lib/include/dots/io/Io.h
+++ b/lib/include/dots/io/Io.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <functional>
 #include <dots/asio.h>

--- a/lib/include/dots/io/Listener.h
+++ b/lib/include/dots/io/Listener.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 #include <optional>

--- a/lib/include/dots/io/Transmission.h
+++ b/lib/include/dots/io/Transmission.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 #include <atomic>

--- a/lib/include/dots/io/auth/AuthManager.h
+++ b/lib/include/dots/io/auth/AuthManager.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <optional>

--- a/lib/include/dots/io/auth/Digest.h
+++ b/lib/include/dots/io/auth/Digest.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <array>
 #include <vector>

--- a/lib/include/dots/io/auth/LegacyAuthManager.h
+++ b/lib/include/dots/io/auth/LegacyAuthManager.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <map>

--- a/lib/include/dots/io/auth/Nonce.h
+++ b/lib/include/dots/io/auth/Nonce.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 

--- a/lib/include/dots/io/channels/AsyncStreamChannel.h
+++ b/lib/include/dots/io/channels/AsyncStreamChannel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #define DOTS_ACKNOWLEDGE_DEPRECATION_OF_DotsTransportHeader_destinationGroup
 #define DOTS_ACKNOWLEDGE_DEPRECATION_OF_DotsTransportHeader_nameSpace

--- a/lib/include/dots/io/channels/LocalChannel.h
+++ b/lib/include/dots/io/channels/LocalChannel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/asio.h>
 #include <dots/io/Channel.h>

--- a/lib/include/dots/io/channels/LocalListener.h
+++ b/lib/include/dots/io/channels/LocalListener.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <functional>
 #include <optional>

--- a/lib/include/dots/io/channels/TcpChannel.h
+++ b/lib/include/dots/io/channels/TcpChannel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/io/channels/AsyncStreamChannel.h>
 

--- a/lib/include/dots/io/channels/TcpListener.h
+++ b/lib/include/dots/io/channels/TcpListener.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/asio.h>

--- a/lib/include/dots/io/channels/UdsChannel.h
+++ b/lib/include/dots/io/channels/UdsChannel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/asio.h>
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)

--- a/lib/include/dots/io/channels/UdsListener.h
+++ b/lib/include/dots/io/channels/UdsListener.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/asio.h>
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)

--- a/lib/include/dots/io/channels/WebSocketChannel.h
+++ b/lib/include/dots/io/channels/WebSocketChannel.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <dots/asio.h>

--- a/lib/include/dots/io/channels/WebSocketListener.h
+++ b/lib/include/dots/io/channels/WebSocketListener.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/asio.h>
 #include <boost/beast.hpp>

--- a/lib/include/dots/serialization/AsciiSerialization.h
+++ b/lib/include/dots/serialization/AsciiSerialization.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 #include <dots/type/StructDescriptor.h>

--- a/lib/include/dots/serialization/CborSerializer.h
+++ b/lib/include/dots/serialization/CborSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <dots/serialization/Serializer.h>

--- a/lib/include/dots/serialization/ExperimentalCborSerializer.h
+++ b/lib/include/dots/serialization/ExperimentalCborSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <stdexcept>

--- a/lib/include/dots/serialization/JsonSerializer.h
+++ b/lib/include/dots/serialization/JsonSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/TextSerializer.h>
 #include <dots/serialization/formats/JsonReader.h>

--- a/lib/include/dots/serialization/RapidJsonSerializer.h
+++ b/lib/include/dots/serialization/RapidJsonSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <dots/serialization/Serializer.h>

--- a/lib/include/dots/serialization/Serializer.h
+++ b/lib/include/dots/serialization/Serializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/TypeVisitor.h>
 

--- a/lib/include/dots/serialization/StringSerializer.h
+++ b/lib/include/dots/serialization/StringSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/TextSerializer.h>
 #include <dots/serialization/formats/StringReader.h>

--- a/lib/include/dots/serialization/TextSerializer.h
+++ b/lib/include/dots/serialization/TextSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <stack>

--- a/lib/include/dots/serialization/formats/CborFormat.h
+++ b/lib/include/dots/serialization/formats/CborFormat.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <cstdint>
 

--- a/lib/include/dots/serialization/formats/CborReader.h
+++ b/lib/include/dots/serialization/formats/CborReader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <stdexcept>

--- a/lib/include/dots/serialization/formats/CborWriter.h
+++ b/lib/include/dots/serialization/formats/CborWriter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <stdexcept>

--- a/lib/include/dots/serialization/formats/JsonFormat.h
+++ b/lib/include/dots/serialization/formats/JsonFormat.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextFormat.h>
 

--- a/lib/include/dots/serialization/formats/JsonReader.h
+++ b/lib/include/dots/serialization/formats/JsonReader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextReader.h>
 #include <dots/serialization/formats/JsonFormat.h>

--- a/lib/include/dots/serialization/formats/JsonWriter.h
+++ b/lib/include/dots/serialization/formats/JsonWriter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextWriter.h>
 #include <dots/serialization/formats/JsonFormat.h>

--- a/lib/include/dots/serialization/formats/RapidJsonReader.h
+++ b/lib/include/dots/serialization/formats/RapidJsonReader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <stack>
 #include <rapidjson/document.h>

--- a/lib/include/dots/serialization/formats/RapidJsonWriter.h
+++ b/lib/include/dots/serialization/formats/RapidJsonWriter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <stack>
 #include <rapidjson/writer.h>

--- a/lib/include/dots/serialization/formats/Reader.h
+++ b/lib/include/dots/serialization/formats/Reader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 namespace dots::serialization

--- a/lib/include/dots/serialization/formats/StringFormat.h
+++ b/lib/include/dots/serialization/formats/StringFormat.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextFormat.h>
 

--- a/lib/include/dots/serialization/formats/StringReader.h
+++ b/lib/include/dots/serialization/formats/StringReader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextReader.h>
 #include <dots/serialization/formats/StringFormat.h>

--- a/lib/include/dots/serialization/formats/StringWriter.h
+++ b/lib/include/dots/serialization/formats/StringWriter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/formats/TextWriter.h>
 #include <dots/serialization/formats/StringFormat.h>

--- a/lib/include/dots/serialization/formats/TextFormat.h
+++ b/lib/include/dots/serialization/formats/TextFormat.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 namespace dots::serialization

--- a/lib/include/dots/serialization/formats/TextReader.h
+++ b/lib/include/dots/serialization/formats/TextReader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <vector>

--- a/lib/include/dots/serialization/formats/TextWriter.h
+++ b/lib/include/dots/serialization/formats/TextWriter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <stack>

--- a/lib/include/dots/serialization/formats/Writer.h
+++ b/lib/include/dots/serialization/formats/Writer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 namespace dots::serialization

--- a/lib/include/dots/testing/gtest/ChannelTestBase.h
+++ b/lib/include/dots/testing/gtest/ChannelTestBase.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <memory>

--- a/lib/include/dots/testing/gtest/EventTestBase.h
+++ b/lib/include/dots/testing/gtest/EventTestBase.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <vector>

--- a/lib/include/dots/testing/gtest/PublishTestBase.h
+++ b/lib/include/dots/testing/gtest/PublishTestBase.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <vector>

--- a/lib/include/dots/testing/gtest/expectations/CallExpectation.h
+++ b/lib/include/dots/testing/gtest/expectations/CallExpectation.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/testing/gtest/gtest.h>
 

--- a/lib/include/dots/testing/gtest/expectations/ExpectationSequence.h
+++ b/lib/include/dots/testing/gtest/expectations/ExpectationSequence.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/testing/gtest/gtest.h>
 

--- a/lib/include/dots/testing/gtest/expectations/PublishExpectation.h
+++ b/lib/include/dots/testing/gtest/expectations/PublishExpectation.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/testing/gtest/matchers/EventMatcher.h>
 

--- a/lib/include/dots/testing/gtest/expectations/TransmitExpectation.h
+++ b/lib/include/dots/testing/gtest/expectations/TransmitExpectation.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/asio.h>
 #include <dots/testing/gtest/gtest.h>

--- a/lib/include/dots/testing/gtest/gtest.h
+++ b/lib/include/dots/testing/gtest/gtest.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/lib/include/dots/testing/gtest/matchers/EventMatcher.h
+++ b/lib/include/dots/testing/gtest/matchers/EventMatcher.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/testing/gtest/printers/EventPrinter.h>
 #include <dots/testing/gtest/matchers/StructMatcher.h>

--- a/lib/include/dots/testing/gtest/matchers/StructMatcher.h
+++ b/lib/include/dots/testing/gtest/matchers/StructMatcher.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <dots/serialization/StringSerializer.h>

--- a/lib/include/dots/testing/gtest/matchers/TransmissionMatcher.h
+++ b/lib/include/dots/testing/gtest/matchers/TransmissionMatcher.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <dots/testing/gtest/printers/TransmissionPrinter.h>

--- a/lib/include/dots/testing/gtest/printers/EventPrinter.h
+++ b/lib/include/dots/testing/gtest/printers/EventPrinter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <iostream>
 #include <dots/Event.h>

--- a/lib/include/dots/testing/gtest/printers/TransmissionPrinter.h
+++ b/lib/include/dots/testing/gtest/printers/TransmissionPrinter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <iostream>
 #include <dots/io/Transmission.h>

--- a/lib/include/dots/testing/gtest/printers/TypePrinter.h
+++ b/lib/include/dots/testing/gtest/printers/TypePrinter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/serialization/StringSerializer.h>
 

--- a/lib/include/dots/tools/Handler.h
+++ b/lib/include/dots/tools/Handler.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <functional>

--- a/lib/include/dots/tools/IpNetwork.h
+++ b/lib/include/dots/tools/IpNetwork.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <variant>

--- a/lib/include/dots/tools/Uri.h
+++ b/lib/include/dots/tools/Uri.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <string_view>

--- a/lib/include/dots/tools/ext_logging.h
+++ b/lib/include/dots/tools/ext_logging.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 #undef LOG_EMERG_P

--- a/lib/include/dots/tools/flf.h
+++ b/lib/include/dots/tools/flf.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 

--- a/lib/include/dots/tools/fun.h
+++ b/lib/include/dots/tools/fun.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #if defined(__cplusplus) || defined(c_plusplus)
 /****************************************************************/

--- a/lib/include/dots/tools/logging.h
+++ b/lib/include/dots/tools/logging.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 #include <cstdarg>

--- a/lib/include/dots/tools/shared_ptr_only.h
+++ b/lib/include/dots/tools/shared_ptr_only.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 

--- a/lib/include/dots/tools/string_tools.h
+++ b/lib/include/dots/tools/string_tools.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <stdexcept>
 #include <string_view>

--- a/lib/include/dots/tools/type_traits.h
+++ b/lib/include/dots/tools/type_traits.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 

--- a/lib/include/dots/type/AnyStruct.h
+++ b/lib/include/dots/type/AnyStruct.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 #include <dots/type/Struct.h>

--- a/lib/include/dots/type/Chrono.h
+++ b/lib/include/dots/type/Chrono.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <string_view>

--- a/lib/include/dots/type/Descriptor.h
+++ b/lib/include/dots/type/Descriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <string_view>

--- a/lib/include/dots/type/DescriptorMap.h
+++ b/lib/include/dots/type/DescriptorMap.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <map>
 #include <memory>

--- a/lib/include/dots/type/DynamicEnum.h
+++ b/lib/include/dots/type/DynamicEnum.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <limits>
 #include <dots/type/FundamentalTypes.h>

--- a/lib/include/dots/type/DynamicStruct.h
+++ b/lib/include/dots/type/DynamicStruct.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <dots/type/Struct.h>

--- a/lib/include/dots/type/EnumDescriptor.h
+++ b/lib/include/dots/type/EnumDescriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <type_traits>

--- a/lib/include/dots/type/FundamentalTypes.h
+++ b/lib/include/dots/type/FundamentalTypes.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/StaticDescriptor.h>
 #include <dots/type/PropertySet.h>

--- a/lib/include/dots/type/LibcTime.h
+++ b/lib/include/dots/type/LibcTime.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <ctime>
 #include <dots/type/Chrono.h>

--- a/lib/include/dots/type/PosixTime.h
+++ b/lib/include/dots/type/PosixTime.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #ifdef __unix__
 #include <string_view>

--- a/lib/include/dots/type/Property.h
+++ b/lib/include/dots/type/Property.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <cstddef>

--- a/lib/include/dots/type/PropertyArea.h
+++ b/lib/include/dots/type/PropertyArea.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/PropertySet.h>
 

--- a/lib/include/dots/type/PropertyContainer.h
+++ b/lib/include/dots/type/PropertyContainer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <type_traits>

--- a/lib/include/dots/type/PropertyDescriptor.h
+++ b/lib/include/dots/type/PropertyDescriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string>
 #include <vector>

--- a/lib/include/dots/type/PropertyInitializer.h
+++ b/lib/include/dots/type/PropertyInitializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <utility>
 #include <type_traits>

--- a/lib/include/dots/type/PropertyIterator.h
+++ b/lib/include/dots/type/PropertyIterator.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <dots/type/ProxyProperty.h>

--- a/lib/include/dots/type/PropertyOffset.h
+++ b/lib/include/dots/type/PropertyOffset.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <utility>
 

--- a/lib/include/dots/type/PropertyPairIterator.h
+++ b/lib/include/dots/type/PropertyPairIterator.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <optional>
 #include <utility>

--- a/lib/include/dots/type/PropertyPath.h
+++ b/lib/include/dots/type/PropertyPath.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/PropertyDescriptor.h>
 

--- a/lib/include/dots/type/PropertySet.h
+++ b/lib/include/dots/type/PropertySet.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <cstdint>
 #include <bitset>

--- a/lib/include/dots/type/ProxyProperty.h
+++ b/lib/include/dots/type/ProxyProperty.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <variant>
 #if (__GNUG__)

--- a/lib/include/dots/type/Registry.h
+++ b/lib/include/dots/type/Registry.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <memory>
 #include <optional>

--- a/lib/include/dots/type/StaticDescriptor.h
+++ b/lib/include/dots/type/StaticDescriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <sstream>

--- a/lib/include/dots/type/StaticProperty.h
+++ b/lib/include/dots/type/StaticProperty.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <optional>

--- a/lib/include/dots/type/StaticPropertyMetadata.h
+++ b/lib/include/dots/type/StaticPropertyMetadata.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
 #include <dots/type/PropertyOffset.h>

--- a/lib/include/dots/type/StaticPropertyOffset.h
+++ b/lib/include/dots/type/StaticPropertyOffset.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/PropertyOffset.h>
 

--- a/lib/include/dots/type/StaticStruct.h
+++ b/lib/include/dots/type/StaticStruct.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <utility>

--- a/lib/include/dots/type/Struct.h
+++ b/lib/include/dots/type/Struct.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <type_traits>
 #include <dots/type/PropertyContainer.h>

--- a/lib/include/dots/type/StructDescriptor.h
+++ b/lib/include/dots/type/StructDescriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/Descriptor.h>
 #include <dots/type/StaticDescriptor.h>

--- a/lib/include/dots/type/TypeVisitor.h
+++ b/lib/include/dots/type/TypeVisitor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/Struct.h>
 #include <dots/type/FundamentalTypes.h>

--- a/lib/include/dots/type/Typeless.h
+++ b/lib/include/dots/type/Typeless.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 
 namespace dots::type

--- a/lib/include/dots/type/Uuid.h
+++ b/lib/include/dots/type/Uuid.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <array>
 #include <string_view>

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <vector>
 #include <dots/type/Typeless.h>

--- a/lib/include/dots/type/VectorDescriptor.h
+++ b/lib/include/dots/type/VectorDescriptor.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/type/StaticDescriptor.h>
 #include <dots/type/Vector.h>

--- a/lib/src/Application.cpp
+++ b/lib/src/Application.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #undef DOTS_NO_GLOBAL_TRANSCEIVER
 #include <dots/Application.h>
 #include <dots/io/Io.h>

--- a/lib/src/Connection.cpp
+++ b/lib/src/Connection.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Connection.h>
 #include <dots/type/Registry.h>
 #include <dots/io/auth/Digest.h>

--- a/lib/src/Container.cpp
+++ b/lib/src/Container.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Container.h>
 #include <algorithm>
 #include <numeric>

--- a/lib/src/ContainerPool.cpp
+++ b/lib/src/ContainerPool.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/ContainerPool.h>
 #include <algorithm>
 #include <utility>

--- a/lib/src/Dispatcher.cpp
+++ b/lib/src/Dispatcher.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Dispatcher.h>
 
 namespace dots

--- a/lib/src/Event.cpp
+++ b/lib/src/Event.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Event.h>
 
 namespace dots

--- a/lib/src/GuestTransceiver.cpp
+++ b/lib/src/GuestTransceiver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/GuestTransceiver.h>
 #include <dots/tools/logging.h>
 #include <dots/serialization/AsciiSerialization.h>

--- a/lib/src/HostTransceiver.cpp
+++ b/lib/src/HostTransceiver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/HostTransceiver.h>
 #include <vector>
 #include <dots/tools/logging.h>

--- a/lib/src/Subscription.cpp
+++ b/lib/src/Subscription.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Subscription.h>
 
 namespace dots

--- a/lib/src/Timer.cpp
+++ b/lib/src/Timer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Timer.h>
 #include <dots/asio.h>
 

--- a/lib/src/Transceiver.cpp
+++ b/lib/src/Transceiver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Transceiver.h>
 #include <dots/tools/logging.h>
 #include <dots/serialization/AsciiSerialization.h>

--- a/lib/src/dots.cpp
+++ b/lib/src/dots.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #undef DOTS_NO_GLOBAL_TRANSCEIVER
 #include <optional>
 #include <dots/dots.h>

--- a/lib/src/io/Channel.cpp
+++ b/lib/src/io/Channel.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/Channel.h>
 #include <cassert>
 #include <dots/type/Registry.h>

--- a/lib/src/io/DescriptorConverter.cpp
+++ b/lib/src/io/DescriptorConverter.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/DescriptorConverter.h>
 #include <dots/type/DynamicStruct.h>
 #include <dots/type/DynamicEnum.h>

--- a/lib/src/io/Endpoint.cpp
+++ b/lib/src/io/Endpoint.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/Endpoint.h>
 
 namespace dots::io

--- a/lib/src/io/FdObserver.cpp
+++ b/lib/src/io/FdObserver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/asio.h>
 #if defined(BOOST_ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
 #include <dots/io/FdObserver.h>

--- a/lib/src/io/Io.cpp
+++ b/lib/src/io/Io.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/Io.h>
 
 namespace dots::io

--- a/lib/src/io/Listener.cpp
+++ b/lib/src/io/Listener.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/Listener.h>
 
 namespace dots::io

--- a/lib/src/io/Transmission.cpp
+++ b/lib/src/io/Transmission.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/Transmission.h>
 
 namespace dots::io

--- a/lib/src/io/auth/AuthManager.cpp
+++ b/lib/src/io/auth/AuthManager.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/auth/AuthManager.h>
 
 namespace dots::io

--- a/lib/src/io/auth/Digest.cpp
+++ b/lib/src/io/auth/Digest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/auth/Digest.h>
 #include <PicoSHA2/picosha2.h>
 #include <boost/algorithm/hex.hpp>

--- a/lib/src/io/auth/LegacyAuthManager.cpp
+++ b/lib/src/io/auth/LegacyAuthManager.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/auth/LegacyAuthManager.h>
 #include <dots/HostTransceiver.h>
 #include <dots/io/auth/Digest.h>

--- a/lib/src/io/auth/Nonce.cpp
+++ b/lib/src/io/auth/Nonce.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/auth/Digest.h>
 #include <random>
 #include <iomanip>

--- a/lib/src/io/channels/LocalChannel.cpp
+++ b/lib/src/io/channels/LocalChannel.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/LocalChannel.h>
 #include <dots/serialization/CborSerializer.h>
 #include <dots/type/Registry.h>

--- a/lib/src/io/channels/LocalListener.cpp
+++ b/lib/src/io/channels/LocalListener.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/LocalListener.h>
 
 namespace dots::io

--- a/lib/src/io/channels/TcpChannel.cpp
+++ b/lib/src/io/channels/TcpChannel.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/TcpChannel.h>
 
 namespace dots::io::details

--- a/lib/src/io/channels/TcpListener.cpp
+++ b/lib/src/io/channels/TcpListener.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/TcpListener.h>
 
 namespace dots::io::details

--- a/lib/src/io/channels/UdsChannel.cpp
+++ b/lib/src/io/channels/UdsChannel.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/asio.h>
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 #include <dots/io/channels/UdsChannel.h>

--- a/lib/src/io/channels/UdsListener.cpp
+++ b/lib/src/io/channels/UdsListener.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/asio.h>
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 #include <dots/io/channels/UdsListener.h>

--- a/lib/src/io/channels/WebSocketChannel.cpp
+++ b/lib/src/io/channels/WebSocketChannel.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/WebSocketChannel.h>
 #include <dots/io/Io.h>
 #include <dots/type/Registry.h>

--- a/lib/src/io/channels/WebSocketListener.cpp
+++ b/lib/src/io/channels/WebSocketListener.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/io/channels/WebSocketListener.h>
 #include <algorithm>
 #include <dots/io/channels/WebSocketChannel.h>

--- a/lib/src/serialization/AsciiSerialization.cpp
+++ b/lib/src/serialization/AsciiSerialization.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/serialization/AsciiSerialization.h>
 #include <dots/type/Struct.h>
 #include <dots/type/EnumDescriptor.h>

--- a/lib/src/tools/IpNetwork.cpp
+++ b/lib/src/tools/IpNetwork.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/tools/IpNetwork.h>
 
 namespace dots::tools

--- a/lib/src/tools/Uri.cpp
+++ b/lib/src/tools/Uri.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/tools/Uri.h>
 #include <dots/tools/string_tools.h>
 

--- a/lib/src/tools/logging.cpp
+++ b/lib/src/tools/logging.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/tools/logging.h>
 #ifdef __unix__
 #include <syslog.h>

--- a/lib/src/type/AnyStruct.cpp
+++ b/lib/src/type/AnyStruct.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/AnyStruct.h>
 
 namespace dots::type

--- a/lib/src/type/Chrono.cpp
+++ b/lib/src/type/Chrono.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <sstream>
 #include <regex>
 #include <charconv>

--- a/lib/src/type/Descriptor.cpp
+++ b/lib/src/type/Descriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/Descriptor.h>
 
 namespace dots::type

--- a/lib/src/type/DescriptorMap.cpp
+++ b/lib/src/type/DescriptorMap.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/DescriptorMap.h>
 #include <stdexcept>
 

--- a/lib/src/type/DynamicEnum.cpp
+++ b/lib/src/type/DynamicEnum.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/DynamicEnum.h>
 
 namespace dots::type

--- a/lib/src/type/DynamicStruct.cpp
+++ b/lib/src/type/DynamicStruct.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/DynamicStruct.h>
 #include <dots/type/FundamentalTypes.h>
 #include <memory>

--- a/lib/src/type/EnumDescriptor.cpp
+++ b/lib/src/type/EnumDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/EnumDescriptor.h>
 #include <dots/type/FundamentalTypes.h>
 

--- a/lib/src/type/PropertyDescriptor.cpp
+++ b/lib/src/type/PropertyDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/PropertyDescriptor.h>
 #include <dots/type/StructDescriptor.h>
 

--- a/lib/src/type/Registry.cpp
+++ b/lib/src/type/Registry.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/Registry.h>
 
 namespace dots::type

--- a/lib/src/type/StaticDescriptor.cpp
+++ b/lib/src/type/StaticDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/StaticDescriptor.h>
 #include <cassert>
 #include <dots/type/FundamentalTypes.h>

--- a/lib/src/type/Struct.cpp
+++ b/lib/src/type/Struct.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/Struct.h>
 #include <dots/type/StructDescriptor.h>
 

--- a/lib/src/type/StructDescriptor.cpp
+++ b/lib/src/type/StructDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/StructDescriptor.h>
 #include <dots/type/Struct.h>
 #include <dots/io/DescriptorConverter.h>

--- a/lib/src/type/TypeVisitor.cpp
+++ b/lib/src/type/TypeVisitor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/TypeVisitor.h>
 
 namespace dots::type

--- a/lib/src/type/Uuid.cpp
+++ b/lib/src/type/Uuid.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/Uuid.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/lib/src/type/VectorDescriptor.cpp
+++ b/lib/src/type/VectorDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/VectorDescriptor.h>
 
 namespace dots::type

--- a/tests/src/TestConnection.cpp
+++ b/tests/src/TestConnection.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <sstream>
 #include <optional>
 #include <dots/Connection.h>

--- a/tests/src/TestContainer.cpp
+++ b/tests/src/TestContainer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/Container.h>
 #include <DotsHeader.dots.h>

--- a/tests/src/TestDispatcher.cpp
+++ b/tests/src/TestDispatcher.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/Dispatcher.h>
 #include <DotsHeader.dots.h>

--- a/tests/src/TestGuestTransceiver.cpp
+++ b/tests/src/TestGuestTransceiver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <sstream>
 #include <optional>
 #include <dots/testing/gtest/EventTestBase.h>

--- a/tests/src/TestHostTransceiver.cpp
+++ b/tests/src/TestHostTransceiver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <optional>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/testing/gtest/EventTestBase.h>

--- a/tests/src/io/auth/TestDigest.cpp
+++ b/tests/src/io/auth/TestDigest.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/io/auth/Digest.h>
 

--- a/tests/src/io/auth/TestLegacyAuthManager.cpp
+++ b/tests/src/io/auth/TestLegacyAuthManager.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <optional>
 #include <boost/algorithm/hex.hpp>
 #include <dots/HostTransceiver.h>

--- a/tests/src/serialization/TestAsciiSerialization.cpp
+++ b/tests/src/serialization/TestAsciiSerialization.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/serialization/AsciiSerialization.h>
 #include "StructDescriptorData.dots.h"
 #include "DotsTestStruct.dots.h"

--- a/tests/src/serialization/TestCborSerializer.cpp
+++ b/tests/src/serialization/TestCborSerializer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/serialization/CborSerializer.h>
 #include <serialization/TestSerializer.h>

--- a/tests/src/serialization/TestExperimentalCborSerializer.cpp
+++ b/tests/src/serialization/TestExperimentalCborSerializer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/serialization/ExperimentalCborSerializer.h>
 #include <serialization/TestSerializer.h>

--- a/tests/src/serialization/TestJsonSerializer.cpp
+++ b/tests/src/serialization/TestJsonSerializer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/serialization/JsonSerializer.h>
 #include <serialization/TestSerializer.h>

--- a/tests/src/serialization/TestRapidJsonSerializer.cpp
+++ b/tests/src/serialization/TestRapidJsonSerializer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/serialization/RapidJsonSerializer.h>
 #include <serialization/TestSerializer.h>

--- a/tests/src/serialization/TestSerializer.h
+++ b/tests/src/serialization/TestSerializer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <dots/testing/gtest/gtest.h>
 

--- a/tests/src/serialization/TestStringSerializer.cpp
+++ b/tests/src/serialization/TestStringSerializer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/serialization/StringSerializer.h>
 #include <serialization/TestSerializer.h>

--- a/tests/src/tools/TestIpNetwork.cpp
+++ b/tests/src/tools/TestIpNetwork.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <vector>
 #include <dots/tools/IpNetwork.h>

--- a/tests/src/tools/TestUri.cpp
+++ b/tests/src/tools/TestUri.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/tools/Uri.h>
 

--- a/tests/src/type/TestChrono.cpp
+++ b/tests/src/type/TestChrono.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <date/date.h>
 #include <date/tz.h>

--- a/tests/src/type/TestDescriptor.cpp
+++ b/tests/src/type/TestDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <string>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/type/Descriptor.h>

--- a/tests/src/type/TestDynamicStruct.cpp
+++ b/tests/src/type/TestDynamicStruct.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <optional>
 #include <dots/type/DynamicStruct.h>
 #include <dots/type/Registry.h>

--- a/tests/src/type/TestEnumDescriptor.cpp
+++ b/tests/src/type/TestEnumDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <sstream>
 #include <dots/type/EnumDescriptor.h>
 #include <dots/type/FundamentalTypes.h>

--- a/tests/src/type/TestProperty.cpp
+++ b/tests/src/type/TestProperty.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <string>
 #include <type_traits>
 #include <dots/testing/gtest/gtest.h>

--- a/tests/src/type/TestPropertyIterator.cpp
+++ b/tests/src/type/TestPropertyIterator.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <algorithm>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/type/PropertyIterator.h>

--- a/tests/src/type/TestPropertySet.cpp
+++ b/tests/src/type/TestPropertySet.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/type/PropertySet.h>
 

--- a/tests/src/type/TestProxyProperty.cpp
+++ b/tests/src/type/TestProxyProperty.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <string>
 #include <type_traits>
 #include <dots/testing/gtest/gtest.h>

--- a/tests/src/type/TestRegistry.cpp
+++ b/tests/src/type/TestRegistry.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/testing/gtest/gtest.h>
 #include <dots/type/Registry.h>
 #include <DotsHeader.dots.h>

--- a/tests/src/type/TestStaticDescriptor.cpp
+++ b/tests/src/type/TestStaticDescriptor.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <string>
 #include <type_traits>
 #include <dots/testing/gtest/gtest.h>

--- a/tests/src/type/TestStaticStruct.cpp
+++ b/tests/src/type/TestStaticStruct.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/StaticStruct.h>
 #include <dots/type/StaticProperty.h>
 #include <dots/type/StaticPropertyOffset.h>

--- a/tests/src/type/TestStaticStructExperimental.cpp
+++ b/tests/src/type/TestStaticStructExperimental.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/type/StaticStruct.h>
 #include <dots/type/StaticProperty.h>
 #include <dots/type/StaticPropertyOffset.h>


### PR DESCRIPTION
Change license of dots-cpp to LGPLv3, Add SPDX-identifier in every source-file

Choose LGPLv3 as license for dots-cpp, to enable users to use it more flexible
as with GPLv3. Especially when used with close-source programs, LGPLv3 allows
users to dynamically link dots-cpp without the need to put the user's work
under GPL too.