### PR TITLE
Improve lib bundling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build-ubuntu-20.04:
+  build_ubuntu_20_04:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -61,7 +61,7 @@ jobs:
       shell: bash
       run: tests/dots-unittests-experimental --gtest_output="xml:report_experimental.xml"
   
-  build-ubuntu-22.04:
+  build_ubuntu_22_04:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  build-ubuntu-20.04:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -24,6 +24,60 @@ jobs:
       
     - name: Install ubuntu dependencies
       run: sudo apt-get install -yq libboost-program-options1.71.0 libboost-dev libboost-all-dev ninja-build
+      
+    - name: Install python dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install dots-code-generator
+      
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: tests/dots-unittests --gtest_output="xml:report.xml"
+
+    - name: Test (experimental features)
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: tests/dots-unittests-experimental --gtest_output="xml:report_experimental.xml"
+  
+  build-ubuntu-22.04:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'true'
+        
+    - name: Update package repositories
+      run: sudo apt-get update -yq
+      
+    - name: Install ubuntu dependencies
+      run: sudo apt-get install -yq libboost-program-options1.74.0 libboost-dev libboost-all-dev ninja-build
       
     - name: Install python dependencies
       run: |

--- a/cmake/LibraryUtils.cmake
+++ b/cmake/LibraryUtils.cmake
@@ -50,10 +50,7 @@ function(bundle_static_library tgt_name)
     endif()
 
     add_custom_command(TARGET ${tgt_name} POST_BUILD
-      COMMAND echo -e "CREATE ${bundled_tgt_full_name}\\n\
-ADDLIB $<JOIN:${static_libs_full_names},\\nADDLIB >\\n\
-SAVE\\n\
-END" > ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
+      COMMAND printf "CREATE ${bundled_tgt_full_name}\\nADDLIB $<JOIN:${static_libs_full_names},\\nADDLIB >\\nSAVE\\nEND" > ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       COMMAND ${ar_tool} -M < ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       COMMAND ${CMAKE_COMMAND} -E copy ${bundled_tgt_full_name} ${tgt_full_name}
       COMMAND ${CMAKE_COMMAND} -E remove ${bundled_tgt_full_name}

--- a/cmake/LibraryUtils.cmake
+++ b/cmake/LibraryUtils.cmake
@@ -1,5 +1,5 @@
 function(bundle_static_library tgt_name)
-  list(APPEND static_libs ${tgt_name})
+  list(APPEND static_libs_full_names $<TARGET_FILE:${tgt_name}>)
 
   function(_recursively_collect_dependencies input_target)
     set(_input_link_libraries LINK_LIBRARIES)
@@ -18,7 +18,7 @@ function(bundle_static_library tgt_name)
         get_target_property(_type ${dependency} TYPE)
 
         if (${_type} STREQUAL "STATIC_LIBRARY")
-          list(APPEND static_libs ${dependency})
+          list(APPEND static_libs_full_names $<TARGET_FILE:${dependency}>)
         endif()
 
         get_property(library_already_added
@@ -29,12 +29,12 @@ function(bundle_static_library tgt_name)
         endif()
       endif()
     endforeach()
-    set(static_libs ${static_libs} PARENT_SCOPE)
+    set(static_libs_full_names ${static_libs_full_names} PARENT_SCOPE)
   endfunction()
 
   _recursively_collect_dependencies(${tgt_name})
 
-  list(REMOVE_DUPLICATES static_libs)
+  list(REMOVE_DUPLICATES static_libs_full_names)
 
   set(bundled_tgt_name ${tgt_name}_bundle)
 
@@ -44,49 +44,30 @@ function(bundle_static_library tgt_name)
   set(tgt_full_name $<TARGET_FILE:${tgt_name}>)
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU)$")
-    file(WRITE ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in
-      "CREATE ${bundled_tgt_full_name}\n" )
-        
-    foreach(tgt IN LISTS static_libs)
-      file(APPEND ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in
-        "ADDLIB $<TARGET_FILE:${tgt}>\n")
-    endforeach()
-    
-    file(APPEND ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in "SAVE\n")
-    file(APPEND ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in "END\n")
-
-    file(GENERATE
-      OUTPUT ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
-      INPUT ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in)
-
     set(ar_tool ${CMAKE_AR})
     if (CMAKE_INTERPROCEDURAL_OPTIMIZATION)
       set(ar_tool ${CMAKE_CXX_COMPILER_AR})
     endif()
 
     add_custom_command(TARGET ${tgt_name} POST_BUILD
+      COMMAND echo -e "CREATE ${bundled_tgt_full_name}\\n\
+ADDLIB $<JOIN:${static_libs_full_names},\\nADDLIB >\\n\
+SAVE\\n\
+END" > ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       COMMAND ${ar_tool} -M < ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       COMMAND ${CMAKE_COMMAND} -E copy ${bundled_tgt_full_name} ${tgt_full_name}
       COMMAND ${CMAKE_COMMAND} -E remove ${bundled_tgt_full_name}
-      BYPRODUCTS
-        ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
-        ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in
+      BYPRODUCTS ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
       COMMENT "Bundling ${bundled_tgt_name}"
-      VERBATIM)
+      VERBATIM
+      )
   elseif(MSVC)
     find_program(lib_tool lib)
-
-    foreach(tgt IN LISTS static_libs)
-      list(APPEND static_libs_full_names $<TARGET_FILE:${tgt}>)
-    endforeach()
 
     add_custom_command(TARGET ${tgt_name} POST_BUILD
       COMMAND ${lib_tool} /NOLOGO /OUT:${bundled_tgt_full_name} ${static_libs_full_names}
       COMMAND ${CMAKE_COMMAND} -E copy ${bundled_tgt_full_name} ${tgt_full_name}
       COMMAND ${CMAKE_COMMAND} -E remove ${bundled_tgt_full_name}
-      BYPRODUCTS
-        ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar
-        ${CMAKE_BINARY_DIR}/${bundled_tgt_name}.ar.in
       COMMENT "Bundling ${bundled_tgt_name}"
       VERBATIM)
   else()


### PR DESCRIPTION
Solve a problem with library-bundling:
The instruction-file for the "ar" utility was created, at cmake generation phase, when one issues a clean on the repository, these
files where delete, but not recreated (until a cmake-reload) and the build failed.
This PR simplifies the creation of the ".ar" file and recreates it before calling "ar".

Also added: Build DOTS using ubuntu-22.04 builder.