### PR TITLE
Verbose serializer exception

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "import/PicoSHA2"]
 	path = external/PicoSHA2
 	url = https://github.com/okdshin/PicoSHA2.git
+[submodule "external/fmt"]
+	path = external/fmt
+	url = https://github.com/fmtlib/fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 # external projects
 add_subdirectory(external/date EXCLUDE_FROM_ALL)
 add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+add_subdirectory(external/fmt EXCLUDE_FROM_ALL)
 
 # allow external packages to be found when cross-compiling
 if (${CMAKE_CROSSCOMPILING})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -143,7 +143,8 @@ target_link_libraries(${TARGET_NAME}
         $<BUILD_INTERFACE:date::date>
         $<BUILD_INTERFACE:date::date-tz>
         $<BUILD_INTERFACE:PicoSHA2::PicoSHA2>
-)
+        $<BUILD_INTERFACE:fmt::fmt>
+        )
 set_target_properties(${TARGET_NAME} PROPERTIES
     SOVERSION 0
 )

--- a/lib/include/dots/io/channels/AsyncStreamChannel.h
+++ b/lib/include/dots/io/channels/AsyncStreamChannel.h
@@ -5,6 +5,7 @@
 #define DOTS_ACKNOWLEDGE_DEPRECATION_OF_DotsTransportHeader_nameSpace
 #define DOTS_ACKNOWLEDGE_DEPRECATION_OF_DotsTransportHeader_destinationClientId
 #include <optional>
+#include <fmt/core.h>
 #include <dots/asio.h>
 #include <dots/type/Registry.h>
 #include <dots/io/Channel.h>
@@ -523,7 +524,7 @@ namespace dots::io
                 }
                 catch (serialization::serializerException& se)
                 {
-                    throw std::runtime_error("deserialization exception in type " + instance->_descriptor().name() + ": " + se.what());
+                    throw std::runtime_error(fmt::format("deserialization exception in type '{}': {}", instance->_descriptor().name(), se.what()));
                 }
 
                 return Transmission{std::move(header), std::move(instance)};

--- a/lib/include/dots/io/channels/AsyncStreamChannel.h
+++ b/lib/include/dots/io/channels/AsyncStreamChannel.h
@@ -9,6 +9,7 @@
 #include <dots/type/Registry.h>
 #include <dots/io/Channel.h>
 #include <dots/serialization/CborSerializer.h>
+#include <dots/serialization/Exceptions.h>
 #include <dots/serialization/ExperimentalCborSerializer.h>
 #include <DotsClient.dots.h>
 #include <DotsDescriptorRequest.dots.h>
@@ -514,10 +515,18 @@ namespace dots::io
             else
             {
                 auto header = m_serializer.template deserialize<DotsHeader>();
-                type::AnyStruct instance{ registry().getStructType(*header.typeName) };
-                m_serializer.deserialize(*instance);
+                type::AnyStruct instance{registry().getStructType(*header.typeName)};
 
-                return Transmission{ std::move(header), std::move(instance) };
+                try
+                {
+                    m_serializer.deserialize(*instance);
+                }
+                catch (serialization::serializerException& se)
+                {
+                    throw std::runtime_error("deserialization exception in type " + instance->_descriptor().name() + ": " + se.what());
+                }
+
+                return Transmission{std::move(header), std::move(instance)};
             }
         }
 

--- a/lib/include/dots/serialization/Exceptions.h
+++ b/lib/include/dots/serialization/Exceptions.h
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
+#pragma once
+#include <stdexcept>
+#include <boost/algorithm/hex.hpp>
+
+namespace dots::serialization
+{
+    struct serializerException : public std::runtime_error
+    {
+        serializerException(const std::string& arg, std::vector<uint8_t> inputBuffer) : runtime_error(arg), m_inputBuffer(std::move(inputBuffer))
+        {
+            parseInputBuffer();
+        };
+
+        [[nodiscard]] const char* what() const noexcept override
+        {
+            return m_final.c_str();
+        }
+
+    private:
+        std::vector<uint8_t> m_inputBuffer;
+        std::string m_final;
+        static int const printLength = 16;
+
+        /*!
+         * @brief convert binary buffer for easier readability
+         */
+        void parseInputBuffer()
+        {
+            m_final += std::runtime_error::what();
+            m_final += "\n";
+
+            auto itStart = m_inputBuffer.begin();
+            auto itAdvance = itStart;
+            std::ranges::advance(itAdvance, printLength, m_inputBuffer.end());
+            for (; itStart < m_inputBuffer.end();)
+            {
+                static int spacer = 0;
+                static int proceeded = 0;
+                for (auto it = itStart; it < itAdvance; it++)
+                {
+                    m_final += boost::algorithm::hex_lower(std::string(it, it + 1));
+                    m_final += " ";
+
+                    if (spacer == printLength / 2 - 1)
+                    {
+                        m_final += " ";
+                    }
+                    spacer++;
+                }
+                spacer = 0;
+
+                if (proceeded != 0)
+                {
+                    m_final += std::string(proceeded * 3, ' ');
+                }
+
+                m_final += "\t";
+
+                for (auto it = itStart; it < itAdvance; it++)
+                {
+                    m_final += (*it < 32) ? '.' : *it;
+                    if (spacer == printLength / 2 - 1)
+                    {
+                        m_final += " ";
+                    }
+                    spacer++;
+                }
+                spacer = 0;
+
+                m_final += "\n";
+                itStart = itAdvance;
+                proceeded = std::ranges::advance(itAdvance, printLength, m_inputBuffer.end());
+            }
+        }
+    };
+}

--- a/lib/include/dots/serialization/formats/CborReader.h
+++ b/lib/include/dots/serialization/formats/CborReader.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <cstring>
 #include <cmath>
+#include <dots/serialization/Exceptions.h>
 #include <dots/serialization/formats/Reader.h>
 #include <dots/serialization/formats/CborFormat.h>
 
@@ -322,7 +323,10 @@ namespace dots::serialization
 
             if (majorType != expectedMajorType)
             {
-                throw std::runtime_error{ "encountered unexpected major type. expected '" + std::to_string(expectedMajorType) + "' but got '" + std::to_string(majorType) + "'" };
+                auto offset = std::distance(inputDataBegin(), inputData());
+                throw serializerException{"encountered unexpected major type at offset " + std::to_string(offset) + ".  expected '" +
+                                          std::to_string(expectedMajorType) + "' but got '" + std::to_string(majorType) + "'",
+                                          std::vector<uint8_t>(inputDataBegin(), inputDataEnd()+1)};
             }
 
             if (additionalInformation <= cbor_t::AdditionalInformation::MaxInplaceValue)

--- a/lib/include/dots/serialization/formats/CborReader.h
+++ b/lib/include/dots/serialization/formats/CborReader.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <cstring>
 #include <cmath>
+#include <fmt/core.h>
 #include <dots/serialization/Exceptions.h>
 #include <dots/serialization/formats/Reader.h>
 #include <dots/serialization/formats/CborFormat.h>
@@ -323,10 +324,11 @@ namespace dots::serialization
 
             if (majorType != expectedMajorType)
             {
-                auto offset = std::distance(inputDataBegin(), inputData());
-                throw serializerException{"encountered unexpected major type at offset " + std::to_string(offset) + ".  expected '" +
-                                          std::to_string(expectedMajorType) + "' but got '" + std::to_string(majorType) + "'",
-                                          std::vector<uint8_t>(inputDataBegin(), inputDataEnd()+1)};
+                throw serializerException{fmt::format("encountered unexpected major type at offset '{}'. expected '{:#04x}' but got '{:#04x}'",
+                                                      std::distance(inputDataBegin(), inputData()),
+                                                      expectedMajorType,
+                                                      majorType),
+                                          std::vector<uint8_t>(inputDataBegin(), inputDataEnd() + 1)};
             }
 
             if (additionalInformation <= cbor_t::AdditionalInformation::MaxInplaceValue)


### PR DESCRIPTION
To provide more information on a serializer exception due to an unexpected major type, the exception becomes more verbose.
The descriptor name and buffer of the processed object are printed as well as the position of the erroneous byte.
This will improve debugging and error tracing.

In consultation with the maintainer, this PR adds the new external dependency [fmtlib](https://github.com/fmtlib/fmt) to improve readability of string manipulations.