### PR TITLE
Improve logging using libfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build*/
 *.pyc
 .vs/
 CMakeSettings.json
+.cache
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Intermediate examples:
 * dots-code-generator >= 0.0.4 (https://github.com/pnxs/dots-code-generator, also available via pip (https://pypi.org/project/dots-code-generator))
 * C++ compiler supporting at least C++20 (such as GCC 11.4, Clang 14 or MSVC 19.26 (VS 2019 16.6))
 
+**❗ BEWARE: MSVC versions >= 19.40 (toolset versions >= 14.40) are currently not fully supported due to a compiler bug. While the library is buildable, certain syntactic constructs might not work properly!**
+
 [^1]: Boost is linked static by default, change cmake-option 'Boost_USE_STATIC_LIBS' to link it shared.
 
 # Build and Run

--- a/lib/include/dots/fmt/hexdump.h
+++ b/lib/include/dots/fmt/hexdump.h
@@ -6,6 +6,7 @@
 #include <span>
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace fmt::extension
 {
@@ -48,7 +49,7 @@ struct fmt::formatter<fmt::extension::hexdump_vector_t<T>>
         //format-switch: if (it != end && (*it == 'b')) presentation = *it++;
 
         // Check if reached the end of the range:
-        if (it != end && *it != '}') throw_format_error("invalid format");
+        if (it != end && *it != '}') throw format_error("invalid format");
 
         // Return an iterator past the end of the parsed range:
         return it;

--- a/lib/include/dots/fmt/logging_fmt.h
+++ b/lib/include/dots/fmt/logging_fmt.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <dots/tools/logging.h>
+#include <fmt/core.h>
+
+#define LOG_F(level, flf, fmtstr, ...) \
+{ \
+using namespace dots::tools; \
+if(loggingFrontend().shouldLog(Level::level)) \
+{ \
+    loggingFrontend().log(Level::level, flf, fmt::format(fmtstr, __VA_ARGS__)); \
+} \
+}
+
+/**
+ * If you want to compile in data-level logs, you have to define DOTS_ENABLE_LOG_DATA
+ */
+#ifdef DOTS_ENABLE_LOG_DATA
+#define LOG_DATA_F(FMT, ...)  LOG_F(data,  FLF, FMT, __VA_ARGS__)
+#else
+#define LOG_DATA_F(...)
+#endif
+
+/**
+ * If you want to compile in debug-level logs, you have to define DOTS_ENABLE_LOG_DATA
+ */
+#ifdef DOTS_ENABLE_LOG_DEBUG
+#define LOG_DEBUG_F(FMT, ...) LOG_F(debug, FLF, FMT, __VA_ARGS__)
+#else
+#define LOG_DEBUG_F(...)
+#endif
+
+#define LOG_INFO_F(FMT, ...)   LOG_F(info,  FLF, FMT, __VA_ARGS__)
+#define LOG_NOTICE_F(FMT, ...) LOG_F(notice,FLF, FMT, __VA_ARGS__)
+#define LOG_WARN_F(FMT, ...)   LOG_F(warn,  FLF, FMT, __VA_ARGS__)
+#define LOG_ERROR_F(FMT, ...)  LOG_F(error, FLF, FMT, __VA_ARGS__)
+#define LOG_CRIT_F(FMT, ...)   LOG_F(crit,  FLF, FMT, __VA_ARGS__)
+#define LOG_EMERG_F(FMT, ...)  LOG_F(emerg, FLF, FMT, __VA_ARGS__)

--- a/lib/include/dots/io/auth/Nonce.h
+++ b/lib/include/dots/io/auth/Nonce.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <string_view>
 #include <cstdint>
+#include <string>
 
 namespace dots::io
 {

--- a/lib/include/dots/serialization/formats/CborReader.h
+++ b/lib/include/dots/serialization/formats/CborReader.h
@@ -226,8 +226,6 @@ namespace dots::serialization
                     }
                 }
 
-                consume(numBytes);
-
                 return value;
             };
 

--- a/lib/include/dots/testing/gtest/PublishTestBase.h
+++ b/lib/include/dots/testing/gtest/PublishTestBase.h
@@ -46,7 +46,7 @@ namespace dots::testing
         {
             if (m_globalGuest != nullptr)
             {
-                global_transceiver().reset();
+                global_transceiver_destroy();
                 m_globalGuest = nullptr;
             }
         }
@@ -88,7 +88,7 @@ namespace dots::testing
         {
             if (m_globalGuest == nullptr)
             {
-                m_globalGuest = &global_transceiver().emplace("dots-global-guest", io::global_io_context(), type::Registry::StaticTypePolicy::All);
+                m_globalGuest = &global_transceiver_create(GuestTransceiver("dots-global-guest", io::global_io_context(), type::Registry::StaticTypePolicy::All));
                 m_globalGuest->open<io::LocalChannel>(io::global_publish_types(), io::global_subscribe_types(), std::optional<std::string>{ std::nullopt }, m_localListener);
                 processEvents();
             }

--- a/lib/include/dots/tools/logging.h
+++ b/lib/include/dots/tools/logging.h
@@ -80,6 +80,7 @@ namespace dots::tools
         [[nodiscard]] bool shouldLog(Level level) const;
         static void log_p(Level level, const Flf &flf, const char* text);
         static void log_s(Level level, const Flf &flf, const std::ostringstream& text);
+        static void log(Level level, const Flf &flf, const std::string& text);
 
     private:
         static std::optional<Level> get_loglevel_from_env();

--- a/lib/include/dots/tools/logging.h
+++ b/lib/include/dots/tools/logging.h
@@ -100,6 +100,7 @@ namespace dots::tools
 
     private:
         bool m_colorOut = false;
+        bool m_logFlf = false;
         static constexpr int MaxLengthLevel = 6;
         std::mutex m_mutex;
     };
@@ -116,6 +117,7 @@ namespace dots::tools
 
         static int toSyslogLevel(Level level);
     private:
+        bool m_logFlf = false;
         std::mutex m_mutex;
     };
 #endif

--- a/lib/include/dots/type/StructDescriptor.h
+++ b/lib/include/dots/type/StructDescriptor.h
@@ -79,8 +79,11 @@ namespace dots::type
         size_t dynamicMemoryUsage(const Typeless& instance) const override;
         size_t dynamicMemoryUsage(const Struct& instance) const;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
         virtual Struct& assign(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual Struct& assign(Struct& instance, Struct&& other, PropertySet includedProperties) const;
+#pragma GCC diagnostic pop
         virtual Struct& copy(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual Struct& merge(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual void swap(Struct& instance, Struct& other, PropertySet includedProperties) const;

--- a/lib/include/dots/type/StructDescriptor.h
+++ b/lib/include/dots/type/StructDescriptor.h
@@ -79,11 +79,15 @@ namespace dots::type
         size_t dynamicMemoryUsage(const Typeless& instance) const override;
         size_t dynamicMemoryUsage(const Struct& instance) const;
 
+#if defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
         virtual Struct& assign(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual Struct& assign(Struct& instance, Struct&& other, PropertySet includedProperties) const;
+#if defined(__GNUG__)
 #pragma GCC diagnostic pop
+#endif
         virtual Struct& copy(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual Struct& merge(Struct& instance, const Struct& other, PropertySet includedProperties) const;
         virtual void swap(Struct& instance, Struct& other, PropertySet includedProperties) const;

--- a/lib/include/dots/type/Uuid.h
+++ b/lib/include/dots/type/Uuid.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <string_view>
 #include <cstdint>
+#include <string>
 
 namespace dots::type
 {

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -75,10 +75,6 @@ namespace dots::type
 
         using vector_t::operator=;
 
-#if defined(__GNUG__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
         Vector& operator = (const Vector<Typeless>& rhs) override
         {
             // TODO: ensure compatible type
@@ -92,9 +88,6 @@ namespace dots::type
             *this = static_cast<Vector&&>(rhs);
             return *this;
         }
-#if defined(__GNUG__)
-#pragma GCC diagnostic pop
-#endif
 
         size_t typelessSize() const noexcept override
         {

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -75,6 +75,8 @@ namespace dots::type
 
         using vector_t::operator=;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
         Vector& operator = (const Vector<Typeless>& rhs) override
         {
             // TODO: ensure compatible type
@@ -88,6 +90,7 @@ namespace dots::type
             *this = static_cast<Vector&&>(rhs);
             return *this;
         }
+#pragma GCC diagnostic pop
 
         size_t typelessSize() const noexcept override
         {

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -46,6 +46,7 @@ namespace dots::type
     {
         using value_t = T;
         using vector_t = std::vector<std::conditional_t<std::is_same_v<T, bool>, uint8_t, T>>;
+        using Vector<Typeless>::operator=;
 
         Vector() = default;
 

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -46,7 +46,6 @@ namespace dots::type
     {
         using value_t = T;
         using vector_t = std::vector<std::conditional_t<std::is_same_v<T, bool>, uint8_t, T>>;
-        using Vector<Typeless>::operator=;
 
         Vector() = default;
 

--- a/lib/include/dots/type/Vector.h
+++ b/lib/include/dots/type/Vector.h
@@ -75,8 +75,10 @@ namespace dots::type
 
         using vector_t::operator=;
 
+#if defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
         Vector& operator = (const Vector<Typeless>& rhs) override
         {
             // TODO: ensure compatible type
@@ -90,7 +92,9 @@ namespace dots::type
             *this = static_cast<Vector&&>(rhs);
             return *this;
         }
+#if defined(__GNUG__)
 #pragma GCC diagnostic pop
+#endif
 
         size_t typelessSize() const noexcept override
         {

--- a/lib/src/Connection.cpp
+++ b/lib/src/Connection.cpp
@@ -3,7 +3,7 @@
 #include <dots/Connection.h>
 #include <dots/type/Registry.h>
 #include <dots/io/auth/Digest.h>
-#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
 #include <dots/serialization/StringSerializer.h>
 #include <DotsMsgConnect.dots.h>
 #include <DotsClient.dots.h>
@@ -21,11 +21,11 @@
 {                                                                                                                                                                   \
     if ((instance_)._descriptor().internal())                                                                                                                       \
     {                                                                                                                                                               \
-        LOG_DATA_S(prefix_ << peerDescription() << "\n" << dots::to_string(header_, StringOptions) << ",\n" << dots::to_string(instance_, StringOptions) << "\n");  \
+        LOG_DATA_F("{}{}\n{},\n{}\n", prefix_, peerDescription(), dots::to_string(header_, StringOptions), dots::to_string(instance_, StringOptions));              \
     }                                                                                                                                                               \
     else                                                                                                                                                            \
     {                                                                                                                                                               \
-        LOG_DEBUG_S(prefix_ << peerDescription() << "\n" << dots::to_string(header_, StringOptions) << ",\n" << dots::to_string(instance_, StringOptions) << "\n"); \
+        LOG_DEBUG_F("{}{}\n{},\n{}\n", prefix_, peerDescription(), dots::to_string(header_, StringOptions), dots::to_string(instance_, StringOptions));             \
     }                                                                                                                                                               \
 }
 #else
@@ -434,21 +434,21 @@ namespace dots
         {
             if (m_connectionState == DotsConnectionState::connecting)
             {
-                LOG_DEBUG_S(peerDescription() << " is establishing connection " << endpointDescription());
+                LOG_DEBUG_F("{} is establishing connection {}", peerDescription(), endpointDescription());
             }
             else if (m_connectionState == DotsConnectionState::early_subscribe)
             {
-                LOG_DEBUG_S(peerDescription() << " is preloading " << endpointDescription());
+                LOG_DEBUG_F("{} is preloading {}", peerDescription(), endpointDescription());
             }
             else if (m_connectionState == DotsConnectionState::connected)
             {
-                LOG_NOTICE_S(peerDescription() << " established connection " << endpointDescription());
+                LOG_NOTICE_F("{} established connection {}", peerDescription(), endpointDescription());
             }
             else if (m_connectionState == DotsConnectionState::closed)
             {
                 if (e == nullptr)
                 {
-                    LOG_NOTICE_S(peerDescription() << " gracefully closed connection");
+                    LOG_NOTICE_F("{} gracefully closed connection", peerDescription());
                 }
                 else
                 {
@@ -458,14 +458,14 @@ namespace dots
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_ERROR_S(peerDescription() << " closed connection with error -> " << e.what());
+                        LOG_ERROR_F("{} closed connection with error -> {}", peerDescription(), e.what());
                     }
                 }
             }
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR_S("error while handling transition for connection " << peerDescription() << " -> " << e.what());
+            LOG_ERROR_F("error while handling transition for connection {} -> {}", peerDescription(), e.what());
         }
 
         try

--- a/lib/src/GuestTransceiver.cpp
+++ b/lib/src/GuestTransceiver.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/GuestTransceiver.h>
-#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
 #include <dots/serialization/AsciiSerialization.h>
 #include <DotsMember.dots.h>
 #include <DotsCacheInfo.dots.h>
@@ -157,7 +157,7 @@ namespace dots
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR_S("error while handling transition for connection " << connection.peerDescription() << " -> " << e.what());
+            LOG_ERROR_F("error while handling transition for connection {} -> {}", connection.peerDescription(), e.what());
             m_hostConnection = nullptr;
         }
     }

--- a/lib/src/HostTransceiver.cpp
+++ b/lib/src/HostTransceiver.cpp
@@ -2,7 +2,7 @@
 // Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/HostTransceiver.h>
 #include <vector>
-#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
 #include <DotsCacheInfo.dots.h>
 #include <DotsClient.dots.h>
 
@@ -133,7 +133,7 @@ namespace dots
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR_S("error while listening for incoming channels -> " << e.what());
+            LOG_ERROR_F("error while listening for incoming channels -> {}", e.what());
         }
 
         m_listeners.erase(&listener);
@@ -215,7 +215,7 @@ namespace dots
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR_S("error while handling transition for connection " << connection.peerDescription() << " -> " << e.what());
+            LOG_ERROR_F("error while handling transition for connection {} -> {}", connection.peerDescription(), e.what());
         }
     }
 
@@ -226,24 +226,24 @@ namespace dots
 
         if (member.event == DotsMemberEvent::kill)
         {
-            LOG_WARN_S(connection.peerDescription() << " requested unsupported kill event");
+            LOG_WARN_F("{} requested unsupported kill event", connection.peerDescription());
         }
         else if (member.event == DotsMemberEvent::leave)
         {
             if (size_t removed = m_groups[groupName].erase(&connection); removed == 0)
             {
-                LOG_WARN_S(connection.peerDescription() << " is not a member of group '" << groupName << "'");
+                LOG_WARN_F("{} is not a member of group '{}'", connection.peerDescription(), groupName);
             }
         }
         else if (member.event == DotsMemberEvent::join)
         {
             if (auto [it, emplaced] = m_groups[groupName].emplace(&connection); emplaced)
             {
-                LOG_DEBUG_S(connection.peerDescription() << " is now a member of group '" << groupName << "'");
+                LOG_DEBUG_F("{} is now a member of group '{}'", connection.peerDescription(), groupName);
             }
             else
             {
-                LOG_WARN_S(connection.peerDescription() << " is already member of group '" << groupName << "'");
+                LOG_WARN_F("{} is already member of group '{}'", connection.peerDescription(), groupName);
             }
 
             // note: transmitting the container content even when the guest has already joined the group is currently
@@ -415,7 +415,7 @@ namespace dots
                 throw std::runtime_error{ "unknown or unsupported endpoint scheme: '" + std::string{ scheme } + "'" };
             }
 
-            LOG_NOTICE_S("listening on endpoint '" << listenEndpoint.uriStr() << "'");
+            LOG_NOTICE_F("listening on endpoint '{}'", listenEndpoint.uriStr());
         }
     }
 }

--- a/lib/src/Transceiver.cpp
+++ b/lib/src/Transceiver.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #include <dots/Transceiver.h>
-#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
 #include <dots/serialization/AsciiSerialization.h>
 #include <DotsMember.dots.h>
 
@@ -95,7 +95,7 @@ namespace dots
             }
             catch (const std::exception& e)
             {
-                LOG_ERROR_S("error in transition handler for " << connection.peerDescription() << " -> " << e.what());
+                LOG_ERROR_F("error in transition handler for {} -> {}", connection.peerDescription(), e.what());
             }
         }
 
@@ -182,7 +182,7 @@ namespace dots
             }
             catch (const std::exception& e)
             {
-                LOG_ERROR_S("error in new type handler for type '" << descriptor.name() << "' -> " << e.what());
+                LOG_ERROR_F("error in new type handler for type '{}' -> {}", descriptor.name(), e.what());
             }
 
             m_currentlyDispatchingId = std::nullopt;
@@ -204,11 +204,11 @@ namespace dots
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR_S("error in subscription handler for type '" << descriptor.name() << "' -> '" << e.what() << "'");
+            LOG_ERROR_F("error in subscription handler for type '{}' -> '{}'", descriptor.name(), e.what());
         }
         catch (...)
         {
-            LOG_ERROR_S("error in subscription handler for type '" << descriptor.name() << "' -> '<unknown>'");
+            LOG_ERROR_F("error in subscription handler for type '{}' -> '<unknown>'", descriptor.name());
         }
     }
 }

--- a/lib/src/io/auth/LegacyAuthManager.cpp
+++ b/lib/src/io/auth/LegacyAuthManager.cpp
@@ -4,7 +4,7 @@
 #include <dots/HostTransceiver.h>
 #include <dots/io/auth/Digest.h>
 #include <dots/tools/IpNetwork.h>
-#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
 
 namespace dots::io
 {
@@ -157,13 +157,17 @@ namespace dots::io
 
                 if ((rule.clientName->empty() || *rule.clientName == clientName) && network.isSubnetOf(tools::IpNetwork{ *rule.network->network, *rule.network->prefix }))
                 {
-                    LOG_DEBUG_S("Match: " << *rule.network->network << "/" << +*rule.network->prefix << " (" << (rule.secret.isValid() ? "with secret" : "without secret") << ", accept=" << *rule.accept << ")");
+                    LOG_DEBUG_F("Match: {}/{} ({}, accept={})",
+                                *rule.network->network,
+                                +*rule.network->prefix,
+                                rule.secret.isValid() ? "with secret" : "without secret",
+                                *rule.accept);
                     matchtingRules.emplace_back(rule);
                 }
             }
             catch (const std::exception& e)
             {
-                LOG_WARN_S("Error processing DotsAuthentication obj: " << e.what());
+                LOG_WARN_F("Error processing DotsAuthentication obj: {}", e.what());
             }
         }
 

--- a/lib/src/serialization/formats/CborReader.cpp
+++ b/lib/src/serialization/formats/CborReader.cpp
@@ -35,7 +35,7 @@ namespace dots::serialization
         throw SerializerException{msg,
                                   details,
                                   offset,
-                                  std::span(inputDataBegin(), inputDataEnd() + 1)};
+                                  std::span(inputDataBegin(), inputDataEnd())};
     }
 
 }

--- a/lib/src/tools/logging.cpp
+++ b/lib/src/tools/logging.cpp
@@ -133,11 +133,11 @@ namespace dots::tools
             flfColor = fmt::emphasis::bold | fmt::fg(fmt::terminal_color::black);
         }
 
-        fmt::print(stderr, "{} {} {} {}\n",
+        fmt::print(stderr, "{} {} {}{}\n",
             fmt::styled(fmt::format("{:<{}}:", level2string(level), MaxLengthLevel), levelColor),
             fmt::styled(fmt::format("[{}]", type::TimePoint::Now().toString()), timeColor),
             text,
-            m_logFlf ? fmt::styled(fmt::format("({}:{} ({}))", flf.file, flf.line, flf.func), flfColor) : fmt::styled(fmt::format(""), flfColor)
+            m_logFlf ? fmt::styled(fmt::format(" ({}:{} ({}))", flf.file, flf.line, flf.func), flfColor) : fmt::styled(fmt::format(""), flfColor)
         );
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(${TARGET_NAME}
         src/tools/TestIpNetwork.cpp
         src/tools/TestUri.cpp
         src/tools/TestHexdump.cpp
+        src/tools/TestLogging.cpp
 
         src/type/TestChrono.cpp
         src/type/TestDescriptor.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(${TARGET_NAME}
         date::date
         date::date-tz
         RapidJSON::RapidJSON
-        fmt::fmt
+        fmt::fmt-header-only
 )
 
 # target [dots-unittests-experimental]

--- a/tests/src/serialization/TestCborSerializer.cpp
+++ b/tests/src/serialization/TestCborSerializer.cpp
@@ -238,16 +238,30 @@ TEST(TestCborSerializerErrors, serializerException)
 
 TEST(TestCborSerializer, skip)
 {
-    CborSerializerTestDataEncoded encoded;
+    const CborSerializerTestDataEncoded& encoded = TestSerializer<CborSerializerTestDataEncoded>::Encoded();
+    const TestSerializerDataDecoded& decoded = TestSerializer<CborSerializerTestDataEncoded>::Decoded();
     dots::serialization::CborSerializer serializer;
 
-    serializer.setInput(encoded.consecutiveTypes1);
+    CborSerializerTestDataEncoded::data_t longString{ 0x78, 0x21, 0x66, 0x6F, 0x6F, 0x5C, 0x20, 0x62, 0x61, 0x72, 0xC2, 0xA9, 0x0A, 0x20, 0x62, 0x5C, 0x61, 0x7A, 0x70, 0x66, 0x6F, 0x6F, 0x5C, 0x20, 0x62, 0x61, 0x72, 0xC2, 0xA9, 0x0A, 0x20, 0x62, 0x5C, 0x61, 0x7A };
 
-    ASSERT_NO_THROW(serializer.reader().skip()); // Skip SerializationStructSimple
+    auto skipStruct = CborSerializerTestDataEncoded::Concat(
+        encoded.structSimple1_Valid,
+        encoded.structComplex2_Valid,
+        encoded.vectorBool,
+        longString,
+        encoded.structComplex1_Valid
+    );
 
-    SerializationStructComplex result;
-    ASSERT_NO_THROW(result = serializer.deserialize<SerializationStructComplex>());
+    serializer.setInput(skipStruct);
 
-    EXPECT_TRUE(result.enumProperty == SerializationEnum::baz);
-    EXPECT_TRUE(result.structSimpleProperty->boolProperty == false);
+    // skip all values until last
+    for (int i = 0; i < 4; ++i)
+    {
+        ASSERT_NO_THROW(serializer.reader().skip());
+    }
+
+    SerializationStructComplex structComplex;
+    ASSERT_NO_THROW(structComplex = serializer.deserialize<SerializationStructComplex>());
+    EXPECT_EQ(structComplex, decoded.structComplex1);
+    EXPECT_FALSE(serializer.inputAvailable());
 }

--- a/tests/src/serialization/TestCborSerializer.cpp
+++ b/tests/src/serialization/TestCborSerializer.cpp
@@ -235,3 +235,19 @@ TEST(TestCborSerializerErrors, serializerException)
     EXPECT_THROW(serializer.Deserialize<dots::bool_t>(encoded.string1), dots::serialization::SerializerException);
 #endif
 }
+
+TEST(TestCborSerializer, skip)
+{
+    CborSerializerTestDataEncoded encoded;
+    dots::serialization::CborSerializer serializer;
+
+    serializer.setInput(encoded.consecutiveTypes1);
+
+    ASSERT_NO_THROW(serializer.reader().skip()); // Skip SerializationStructSimple
+
+    SerializationStructComplex result;
+    ASSERT_NO_THROW(result = serializer.deserialize<SerializationStructComplex>());
+
+    EXPECT_TRUE(result.enumProperty == SerializationEnum::baz);
+    EXPECT_TRUE(result.structSimpleProperty->boolProperty == false);
+}

--- a/tests/src/serialization/TestSerializer.h
+++ b/tests/src/serialization/TestSerializer.h
@@ -194,8 +194,6 @@ struct SerializerTestDataEncoded
 template <typename TEncoded>
 struct TestSerializer : ::testing::Test
 {
-protected:
-
     using decoded_t = TestSerializerDataDecoded;
     using encoded_t = TEncoded;
 

--- a/tests/src/tools/TestLogging.cpp
+++ b/tests/src/tools/TestLogging.cpp
@@ -75,10 +75,11 @@ TEST_F(TestLogging, test_levels)
     fmt::print("tFmt...: {}\n", tFmt.count());
 }
 
-TEST_F(TestLogging, test_consolebackend_bw)
+TEST_F(TestLogging, test_consolebackend_bw_flf)
 {
     ::testing::internal::CaptureStderr();
     setenv("DOTS_DISABLE_LOG_COLORS", "1", 1);
+    setenv("DOTS_LOG_FLF", "1", 1);
 
     dots::tools::ConsoleLogBackend consoleLogBackend;
 
@@ -88,4 +89,20 @@ TEST_F(TestLogging, test_consolebackend_bw)
     std::string logout = testing::internal::GetCapturedStderr();
 
     EXPECT_THAT(logout, MatchesRegex("info  : \\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\\+[0-9]{2}:[0-9]{2}\\] message \\(file:42 \\(function\\)\\)\n"));
+}
+
+TEST_F(TestLogging, test_consolebackend_bw)
+{
+    ::testing::internal::CaptureStderr();
+    setenv("DOTS_DISABLE_LOG_COLORS", "1", 1);
+    unsetenv("DOTS_LOG_FLF");
+
+    dots::tools::ConsoleLogBackend consoleLogBackend;
+
+    auto flf = dots::tools::Flf("file", 42, "function");
+    consoleLogBackend.log(dots::tools::Level::info, flf, "message" );
+
+    std::string logout = testing::internal::GetCapturedStderr();
+
+    EXPECT_THAT(logout, MatchesRegex("info  : \\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\\+[0-9]{2}:[0-9]{2}\\] message\n"));
 }

--- a/tests/src/tools/TestLogging.cpp
+++ b/tests/src/tools/TestLogging.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
+#include <dots/testing/gtest/gtest.h>
+#include <vector>
+#include <dots/tools/logging.h>
+#include <dots/fmt/logging_fmt.h>
+
+using ::testing::MatchesRegex;
+
+struct TestLogging : ::testing::Test
+{
+};
+
+TEST_F(TestLogging, test_levels)
+{
+    int iterations = 1;
+    ::testing::internal::CaptureStderr();
+    LOG_INFO_S("Info" << "Warmup")
+
+    std::string str1 = "name";
+    std::string str2 = "log";
+
+    dots::tools::loggingFrontend().setLogLevel(1);
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        LOG_DATA_S(str1 << " Data " << str2)
+        LOG_DEBUG_S(str1 << " Debug " << str2)
+        LOG_INFO_S(str1 << " Info " << str2)
+        LOG_NOTICE_S(str1 << " Notice " << str2)
+        LOG_WARN_S(str1 << " Warn " << str2)
+        LOG_ERROR_S(str1 << " Error " << str2)
+        LOG_CRIT_S(str1 << " Critical " << str2)
+        LOG_EMERG_S(str1 << " Emergency " << str2)
+    }
+
+    auto t2 = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        LOG_DATA_P("%s Data %s",str1.c_str(), str2.c_str())
+        LOG_DEBUG_P("%s Debug %s",str1.c_str(), str2.c_str())
+        LOG_INFO_P("%s Info %s",str1.c_str(), str2.c_str())
+        LOG_NOTICE_P("%s Notice %s",str1.c_str(), str2.c_str())
+        LOG_WARN_P("%s Warn %s",str1.c_str(), str2.c_str())
+        LOG_ERROR_P("%s Error %s",str1.c_str(), str2.c_str())
+        LOG_CRIT_P("%s Critical %s",str1.c_str(), str2.c_str())
+        LOG_EMERG_P("%s Emergency %s",str1.c_str(), str2.c_str())
+    }
+    auto t3 = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        LOG_DATA_F("{} Data {}", str1, str2);
+        LOG_DEBUG_F("{} Debug {}", str1, str2);
+        LOG_INFO_F("{} Info {}", str1, str2);
+        LOG_NOTICE_F("{} Notice {}", str1, str2);
+        LOG_WARN_F("{} Warn {}", str1, str2);
+        LOG_ERROR_F("{} Error {}", str1, str2);
+        LOG_CRIT_F("{} Critical {}", str1, str2);
+        LOG_EMERG_F("{} Emergency {}", str1, str2);
+    }
+    auto t4 = std::chrono::high_resolution_clock::now();
+
+    std::string logout = testing::internal::GetCapturedStderr();
+
+    auto tStream = t2 - t1;
+    auto tPrintf = t3 - t2;
+    auto tFmt = t4 - t3;
+
+    fmt::print("tStream: {}\n", tStream.count());
+    fmt::print("tPrintf: {}\n", tPrintf.count());
+    fmt::print("tFmt...: {}\n", tFmt.count());
+}
+
+TEST_F(TestLogging, test_consolebackend_bw)
+{
+    ::testing::internal::CaptureStderr();
+    setenv("DOTS_DISABLE_LOG_COLORS", "1", 1);
+
+    dots::tools::ConsoleLogBackend consoleLogBackend;
+
+    auto flf = dots::tools::Flf("file", 42, "function");
+    consoleLogBackend.log(dots::tools::Level::info, flf, "message" );
+
+    std::string logout = testing::internal::GetCapturedStderr();
+
+    EXPECT_THAT(logout, MatchesRegex("info  : \\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\\+[0-9]{2}:[0-9]{2}\\] message \\(file:42 \\(function\\)\\)\n"));
+}

--- a/tests/src/tools/TestLogging.cpp
+++ b/tests/src/tools/TestLogging.cpp
@@ -75,6 +75,16 @@ TEST_F(TestLogging, test_levels)
     fmt::print("tFmt...: {}\n", tFmt.count());
 }
 
+// WORKAROUND
+//
+// The following tests are currently only available on POSIX platforms,
+// because they require regular expressions that are not available with
+// GoogleTest's simplified syntax (see [1])
+//
+// References:
+//
+// - [1] https://google.github.io/googletest/advanced.html#regular-expression-syntax
+#if defined(GTEST_USES_POSIX_RE)
 TEST_F(TestLogging, test_consolebackend_bw_flf)
 {
     ::testing::internal::CaptureStderr();
@@ -106,3 +116,4 @@ TEST_F(TestLogging, test_consolebackend_bw)
 
     EXPECT_THAT(logout, MatchesRegex("info  : \\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\\+[0-9]{2}:[0-9]{2}\\] message\n"));
 }
+#endif

--- a/tests/src/type/TestEnumDescriptor.cpp
+++ b/tests/src/type/TestEnumDescriptor.cpp
@@ -21,6 +21,7 @@ namespace dots::types
     {
         using underlying_type_t = dots::vector_t<string_t>;
         using dots::vector_t<string_t>::vector_t;
+        using dots::vector_t<string_t>::operator=;
     };
 }
 

--- a/tests/src/type/TestEnumDescriptor.cpp
+++ b/tests/src/type/TestEnumDescriptor.cpp
@@ -21,7 +21,6 @@ namespace dots::types
     {
         using underlying_type_t = dots::vector_t<string_t>;
         using dots::vector_t<string_t>::vector_t;
-        using dots::vector_t<string_t>::operator=;
     };
 }
 

--- a/tests/src/type/TestEnumDescriptor.cpp
+++ b/tests/src/type/TestEnumDescriptor.cpp
@@ -21,6 +21,7 @@ namespace dots::types
     {
         using underlying_type_t = dots::vector_t<string_t>;
         using dots::vector_t<string_t>::vector_t;
+        using dots::type::Vector<std::string>::operator=;
     };
 }
 

--- a/tests/src/type/TestProperty.cpp
+++ b/tests/src/type/TestProperty.cpp
@@ -167,6 +167,26 @@ TEST_F(TestProperty, swap_OppositeValuesAfterInvalidSwap)
     EXPECT_EQ(m_sutLhs.value(), "bar");
 }
 
+// WORKAROUND
+//
+// The following tests do not build with MSVC versions 19.40 and latest
+// (currently 14.42.34433), because syntactic constructs in the form of
+// 'TestStruct{}.stringProperty' result in an 'internal compiler
+// error'.
+//
+// This is most likely due to a compiler bug related to union classes,
+// which are used for the storage of property values. An isolated
+// version of the issue can be inspected in the Compiler Explorer (see
+// [1]), which shows that everything works as intended for GCC and
+// Clang, as well as MSVC versions up to 19.39.
+//
+// Note that we did not yet report the issue and it is unclear whether
+// it is being worked on by the MSVC team.
+//
+// References:
+//
+// - [1] https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM1ykrgAyeAyYAHI%2BAEaYxBIAbKQADqgKhE4MHt6%2B/oGp6Y4CoeFRLLHxXEl2mA6ZQgRMxATZPn4Btpj2RQwNTQQlkTFxibaNza25HQrjA2FD5SNVAJS2qF7EyOwc5gDMYcjeWADUJrtuM8RhwGfYJhoAgnsHR5in5wQAnsmYAPoExCYhAUt3uT0ezDYCmSTC2xwImBmYJMAHYrI9jpjjpcvA5jugfCxPv8wVjTmjSVjUQARM7o8EPMkIljJAwI95uL4/SFvY4AFVIx2iqE872p2II6BAIDwCn%2BVwAbngxLRiVgcXVovRfgqzm4%2BaDdncMViNQQJSQmMA/gRKZjUfSyWSvAxMnanQ73U6sQSWET/vjCZ86V7vfzjgqxF5MCGTd6abHGVSUbTdvT3czWUx2XquYxWG8DUb3WaLYDrSTzgLjlQxEpQXHyY6wy63Y2yZ722Hff7zT3g2nQ96%2BRGozHB137SnE0Oy1abRBlscGKhMKotslzSBA37gxSU02E49ZzNLRWCBA0AwZnPz%2BYEkuV2uN%2BbPdPJ7eF6fyzb7/fjqgBAIHEj6ruumCboe74MmGxwAH7fvO/yLsuYEvrOnZJrBmIAPQ4ccCCGOg9DoMca4IsQzC0KqGHQSeRA/iSZgJABPyAgxYrHJeAg3ohd7MccxAIAooHPhBr5ooJmAEBsDDHAAVEBsp0uStIfnxv4CagbHZiQnEQBpTEJP%2BQkiahYmQQ6UkyZRClKSCaaqe6CYTjBpoAri5oAGIis5FIfnhhm2ucYTBdgQpNImsFBXqMxSiAlzXLcEXEFFyapumdGPAqqB4KR/CoNETSLsi/lYccV43kwXhEP%2BBVFcQnEIjM0o%2Bagb7UgAdA1aWYhAOV5cs9WRa5NIcKstCcAArLwfgcFopCoJwbjWNY2LrJsbx7DwpAEJo42rAA1iAuy7J1p0XZdV1JJNHCSLN%2B2LZwvAKCAGi7ftqxwLASBoCydBxOQlB/ckAPxAqyDJMkOpcAAnL8uzwwAakIXAor88OqAk0g0LQFGvRA0SPdEYRNJ8nA7STzDEJ8ADy0TaLUe3cLwf1sIItMMKqj1YNEXjAG4KqvSzpBYCwhjAOI828PgxBM3gCqIo9a61DV2w7aFXSPbQeDRICNMeFgj0AngLAU7wivEMKSjUpg4tGDrRifXwBjAAoSN4JgADutPcubMiCCIYjsFIAfyEoaiPbogQGE7piWNY%2Bi669kCrNpPTC7wqCW1c6rwKsNR1M4ECuJMfiBCE8xlBUegFBkAhl7XaT1wwgzV0snTdPUsyN4Ehc9H0zRt8MlRjP0vdj0PVcjxIBcbVss/6NND3S09HDHFjkjHCwCgQxGcPnbDxwo2jnVHxAuCEHp23LLwzNaMsR0nWdV2vxdN2cPdpBzQtS0cC9b0PrSy%2BjARAIB1gEGSDVIG3F/r0GIBEAsnBVAAA4EgAFpsYVVjsAY4B8uCdQWpgfADE8p6H4IHUQ4hQ4UPDiodQq9o6kC9oCZI5sJrL2/o9P%2BtMapQPNKgKgG8sE7z3gqA%2BiNj6oxRGfLiHg4FxFOGYXYXBb5AIfk/U65036vyXndFev9nq2EAffA6eizAGKzkY0xj9SCW3SM4SQQA%3D%3D
+#if !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 194000000
 TEST_F(TestProperty, CompareEqualityOfPropertyWithProperty)
 {
     // invalid lhs, invalid rhs
@@ -453,3 +473,4 @@ TEST_F(TestProperty, CompareOrderingOfPropertyWithInvalid)
         EXPECT_FALSE(dots::invalid >= validProperty);
     }
 }
+#endif


### PR DESCRIPTION
Add a new logging macro LOG_x_F, that can be used by including <dots/fmt/logging_fmt.h>.
Use the new logging macro in DOTS without exposing libfmt in the interface.