### PR TITLE
Channel: export types when sending trough a DescriptorData object

### DIFF
--- a/lib/include/dots/io/Channel.h
+++ b/lib/include/dots/io/Channel.h
@@ -66,6 +66,7 @@ namespace dots::io
 
         void importDependencies(const type::Struct& instance);
         void exportDependencies(const type::Descriptor<>& descriptor);
+        void exportDependencies(const type::Struct& instance);
 
         std::set<std::string> m_sharedTypeNames;
         std::unordered_set<const type::Descriptor<>*> m_sharedTypeDescriptors;

--- a/lib/include/dots/io/auth/Nonce.h
+++ b/lib/include/dots/io/auth/Nonce.h
@@ -2,6 +2,7 @@
 // Copyright 2015-2022 Thomas Schaetzlein <thomas@pnxs.de>, Christopher Gerlach <gerlachch@gmx.com>
 #pragma once
 #include <string_view>
+#include <cstdint>
 
 namespace dots::io
 {

--- a/lib/include/dots/serialization/SerializerException.h
+++ b/lib/include/dots/serialization/SerializerException.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <stdexcept>
 #include <span>
+#include <cstdint>
 
 namespace dots::serialization
 {

--- a/lib/include/dots/tools/Uri.h
+++ b/lib/include/dots/tools/Uri.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <cstdint>
 
 namespace dots::tools
 {

--- a/lib/include/dots/type/Uuid.h
+++ b/lib/include/dots/type/Uuid.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <array>
 #include <string_view>
+#include <cstdint>
 
 namespace dots::type
 {

--- a/lib/src/io/Channel.cpp
+++ b/lib/src/io/Channel.cpp
@@ -222,16 +222,16 @@ namespace dots::io
         // and EnumDescriptorData) and another client is just in the process sending it descriptors, but the dynamic client
         // did not receive the start of the transmission-sequence. In that case it could otherwise not resolve the dependent
         // types, because it may not have received them yet.
-        if (auto structDescriptorData = instance._as<StructDescriptorData>())
+        if (auto* structDescriptorData = instance._as<StructDescriptorData>())
         {
-            auto embeddedDescriptor = registry().findStructType(*structDescriptorData->name);
+            auto* embeddedDescriptor = registry().findStructType(*structDescriptorData->name);
             if (embeddedDescriptor) {
                 exportDependencies(*embeddedDescriptor);
             }
         }
-        else if (auto enumDescriptorData = instance._as<EnumDescriptorData>())
+        else if (auto* enumDescriptorData = instance._as<EnumDescriptorData>())
         {
-            auto embeddedDescriptor = m_registry->findEnumType(*enumDescriptorData->name);
+            auto* embeddedDescriptor = m_registry->findEnumType(*enumDescriptorData->name);
             if (embeddedDescriptor) {
                 exportDependencies(*embeddedDescriptor);
             }

--- a/lib/src/io/Channel.cpp
+++ b/lib/src/io/Channel.cpp
@@ -81,7 +81,7 @@ namespace dots::io
     void Channel::transmit(const Transmission& transmission)
     {
         assert(m_initialized);
-        exportDependencies(transmission.instance()->_descriptor());
+        exportDependencies(transmission.instance());
         transmitImpl(transmission);
     }
 
@@ -171,8 +171,7 @@ namespace dots::io
             if (bool isNewSharedType = m_sharedTypeNames.count(*structDescriptorData->name) == 0; isNewSharedType)
             {
                 m_sharedTypeNames.emplace(*structDescriptorData->name);
-                const type::StructDescriptor& descriptor = DescriptorConverter{ registry() }(*structDescriptorData);
-                m_sharedTypeDescriptors.emplace(&descriptor);
+                m_sharedTypeDescriptors.emplace(&DescriptorConverter{ registry() }(*structDescriptorData));
             }
         }
         else if (auto* enumDescriptorData = instance._as<EnumDescriptorData>())
@@ -180,8 +179,7 @@ namespace dots::io
             if (bool isNewSharedType = m_sharedTypeNames.count(*enumDescriptorData->name) == 0; isNewSharedType)
             {
                 m_sharedTypeNames.emplace(*enumDescriptorData->name);
-                const type::EnumDescriptor& descriptor = DescriptorConverter{ registry() }(*enumDescriptorData);
-                m_sharedTypeDescriptors.emplace(&descriptor);
+                m_sharedTypeDescriptors.emplace(&DescriptorConverter{ registry() }(*enumDescriptorData));
             }
         }
     }
@@ -212,6 +210,30 @@ namespace dots::io
 
                     transmit(DescriptorConverter{ registry() }(*structDescriptor));
                 }
+            }
+        }
+
+    }
+
+    void Channel::exportDependencies(const type::Struct& instance)
+    {
+        // If descriptor is for type StructDescriptorData or EnumDescriptorData, check if dependent types has to be exported first.
+        // This can happen if e.g. a dynamic client sends a DescriptorRequest (and is therefore joined for StructDescriptorData
+        // and EnumDescriptorData) and another client is just in the process sending it descriptors, but the dynamic client
+        // did not receive the start of the transmission-sequence. In that case it could otherwise not resolve the dependent
+        // types, because it may not have received them yet.
+        if (auto structDescriptorData = instance._as<StructDescriptorData>())
+        {
+            auto embeddedDescriptor = registry().findStructType(*structDescriptorData->name);
+            if (embeddedDescriptor) {
+                exportDependencies(*embeddedDescriptor);
+            }
+        }
+        else if (auto enumDescriptorData = instance._as<EnumDescriptorData>())
+        {
+            auto embeddedDescriptor = m_registry->findEnumType(*enumDescriptorData->name);
+            if (embeddedDescriptor) {
+                exportDependencies(*embeddedDescriptor);
             }
         }
     }


### PR DESCRIPTION
A out-of-order descriptor can be received when a program A sends a DescriptorRequest to dotsd while simultaneously another program B is in the process of sending its descriptors but program A missed dependent types. Program A would try to register the new type and fail, because it could not resolve the dependent types.
This change ensures, that even for this types the server sends the dependent types into the stream to program A.